### PR TITLE
feat: added gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# fixed  LF
+* text=auto
+*.js eol=lf
+*.jsx eol=lf
+*.ts eol=lf
+*.tsx eol=lf
+*.css eol=lf
+*.scss eol=lf
+*.json eol=lf
+*.md eol=lf
+*.astro eol=lf

--- a/README.md
+++ b/README.md
@@ -7,69 +7,89 @@
 ## Technologies Used
 
 ### Astro
+
 - **Description**: Astro is a modern framework for building fast and dynamic websites. It uses a component-based architecture and allows the integration of multiple technologies.
 - **Documentation**: [Astro Docs](https://docs.astro.build/)
 
 ### React
+
 - **Description**: React is a JavaScript library for building user interfaces. It allows creating reusable components and managing the application state efficiently.
 - **Documentation**: [React Docs](https://reactjs.org/docs/getting-started.html)
 
 ### ESLint
+
 - **Description**: ESLint is a tool for identifying and reporting on patterns found in JavaScript code, with the goal of making the code more consistent and avoiding bugs.
 - **Configuration for Astro**: We have configured ESLint to work specifically with Astro, ensuring that the code adheres to the project's standards and best practices.
 - **Documentation**: [ESLint Docs](https://eslint.org/docs/user-guide/getting-started)
 
 ### Stylelint
+
 - **Description**: Stylelint is a tool for analyzing and fixing CSS code, helping maintain consistent styles and avoiding common errors.
 - **Documentation**: [Stylelint Docs](https://stylelint.io/)
 
 ### Node.js
+
 - **Description**: Node.js is a JavaScript runtime built on Chrome's V8 JavaScript engine, allowing the execution of JavaScript code on the server.
 - **Version**: 18.19
 - **Documentation**: [Node.js Docs](https://nodejs.org/en/docs/)
 
 ### Prettier
+
 - **Description**: Prettier is a code formatter that ensures consistent style throughout the codebase, regardless of who writes the code.
 - **Documentation**: [Prettier Docs](https://prettier.io/docs/en/index.html)
 - **Fixing Issues**: If there are any issues with Prettier, use the command:
   ```sh
   yarn prettier:fix
-### Husky 
-- **Description: Husky is a tool for managing Git hooks, allowing the execution of scripts at specific points in the Git workflow.
-- **Documentation: [Husky Docs](https://typicode.github.io/husky/)
+  ```
+
+### Husky
+
+- \*\*Description: Husky is a tool for managing Git hooks, allowing the execution of scripts at specific points in the Git workflow.
+- \*\*Documentation: [Husky Docs](https://typicode.github.io/husky/)
 
 ### Storybook
+
 - **Description**: Storybook is a tool for developing and documenting UI components in isolation, allowing for the independent building and testing of components.
 - **Documentation**: [Storybook Docs](https://storybook.js.org/docs/react/get-started/introduction)
 
 ### Vite
+
 - **Description**: Vite is a fast development environment for modern web projects, offering a quick build time and agile development experience.
 - **Documentation**: [Vite Docs](https://vitejs.dev/guide/)
 
 ### Vitest
+
 - **Description**: Vitest is a testing framework that works seamlessly with Vite, providing a fast and efficient testing experience.
 - **Documentation**: [Vitest Docs](https://vitest.dev/)
 
 ### Playwright
+
 - **Description**: Playwright is a browser automation tool that enables end-to-end testing with a powerful and flexible API.
 - **Documentation**: [Playwright Docs](https://playwright.dev/docs/intro)
 
 - ## Installation and Usage
 
 **Clone the repository**:
+
 ```sh
 git clone https://github.com/your-username/openscience.git
 cd openscience
 ```
+
 ### Install dependencies
+
 ```sh
 yarn install
 ```
+
 ### Start the development environment:
+
 ```sh
 yarn dev
 ```
+
 ### Contribution
+
 To contribute to this project, please follow these steps:
 Fork the repository.
 Create a new branch (git checkout -b feature/new-feature).

--- a/src/globals/_breakpoints.scss
+++ b/src/globals/_breakpoints.scss
@@ -1,4 +1,4 @@
-$breakpoints: (
+$ads-breakpoints-scales: (
   'small': 480px,
   'medium': 768px,
   'large': 1024px,

--- a/src/globals/_mixins.scss
+++ b/src/globals/_mixins.scss
@@ -1,13 +1,11 @@
 @import 'breakpoints';
 
 @mixin respond-to($breakpoint) {
-  @if map-has-key($breakpoints, $breakpoint) {
-    @media (min-width: map-get($breakpoints, $breakpoint)) {
+  @if map-has-key($ads-breakpoints-scales, $breakpoint) {
+    @media (min-width: map-get($ads-breakpoints-scales, $breakpoint)) {
       @content;
     }
-  }
-
- @else {
+  } @else {
     @warn "It has not been found: #{$breakpoint}.";
   }
 }

--- a/style-guide/stylelint.json
+++ b/style-guide/stylelint.json
@@ -18,7 +18,8 @@
     ],
     "max-nesting-depth": 3,
     "order/order": ["custom-properties", "declarations"],
-    "order/properties-alphabetical-order": true
+    "order/properties-alphabetical-order": true,
+    "scss/dollar-variable-pattern": "^ads(-[a-z]+){2,3}$"
   },
   "overrides": [
     {


### PR DESCRIPTION
This PR adds a new rule to Stylelint that allows handling variables in the format $ads-[descriptor]-[property]: [value]; and $ads-[descriptor]-[property]-[variation]: [value];. Additionally, a .gitattributes file is included to prevent Git from changing LF to CRLF by default. This will avoid overusing yarn prettier