### PR TITLE
[SEM-317] Refactor, isolar los estilos de los componentes SEM-069 & SEM-070

### DIFF
--- a/src/ui/components/atoms/close-download-button/CloseDownloadButton.module.scss
+++ b/src/ui/components/atoms/close-download-button/CloseDownloadButton.module.scss
@@ -6,62 +6,63 @@
   border: none;
   height: 3.5rem;
   padding: 1.3rem;
+  transition: background-color 0.3s ease;
   width: 3rem;
 
   @include respond-to('small') {
-    background: $ads-text-main;
     height: 3.5rem;
     width: 3rem;
   }
 
   @include respond-to('medium') {
-    background: $ads-text-main;
     height: 4.5rem;
     width: 4rem;
   }
 
   @include respond-to('large') {
-    background: $ads-text-main;
     height: 5.5rem;
     width: 5rem;
   }
 
   @include respond-to('extra-large') {
-    background: $ads-text-main;
     height: 6rem;
     width: 5.2rem;
   }
 
-  .button__icon svg {
-    display: flexbox;
+  &:hover {
+    background: linear-gradient(to bottom right, $ads-text-main, $ads-text-main-hover);
+  }
+
+  .button-icon {
+    display: flex;
     height: 100%;
     width: 100%;
+
+    svg {
+      height: 100%;
+      width: 100%;
+    }
+
+    &--primary {
+      path {
+        fill: $ads-text-main;
+      }
+    }
+
+    &--secondary {
+      path {
+        fill: $ads-text-main;
+      }
+    }
   }
 
-  .button__icon #path {
-    display: flexbox;
-    fill: $ads-text-main;
-
-    @include respond-to('large') {
+  &:hover .button-icon path {
+    @include respond-to('small') {
       fill: $ads-text-main;
     }
 
-    @include respond-to('extra-large') {
+    @include respond-to('medium') {
       fill: $ads-text-main;
-    }
-  }
-
-  .close-download-button:hover {
-    background: $ads-text-main;
-
-    .button__icon #path {
-      @include respond-to('small') {
-        fill: $ads-text-main;
-      }
-
-      @include respond-to('medium') {
-        fill: $ads-text-main;
-      }
     }
   }
 }

--- a/src/ui/components/atoms/close-download-button/CloseDownloadButton.tsx
+++ b/src/ui/components/atoms/close-download-button/CloseDownloadButton.tsx
@@ -1,13 +1,18 @@
-import './CloseDownloadButton.scss';
+import styles from './CloseDownloadButton.module.scss';
 import type { IProps } from './types/IProps';
 import { Icon } from '../../../utils/svg-icons/icons';
 
 function CloseDownloadButton(props: IProps) {
   const { icon, onClick, color } = props;
-  const colorFont = `button__icon--${color as string}`;
+  const colorFont = styles[color as keyof typeof styles];
+
   return (
-    <button className={`close-download-button ${colorFont}`} aria-label="Abrir" onClick={onClick}>
-      {icon && <Icon data-testid="button-icon" src={icon} className="button__icon" />}
+    <button
+      className={`${styles['close-download-button']} ${colorFont}`}
+      aria-label="Abrir"
+      onClick={onClick}
+    >
+      {icon && <Icon data-testid="button-icon" src={icon} className={styles.buttonIcon} />}
     </button>
   );
 }

--- a/src/ui/components/atoms/error-message/ErrorMessage.module.scss
+++ b/src/ui/components/atoms/error-message/ErrorMessage.module.scss
@@ -1,9 +1,9 @@
 @import '../../../../globals/variables';
 @import '../../../../globals/mixins';
 
-.error-message {
+.errorMessage {
   color: $ads-primary-main;
-  font-family: Inter, sans-serif;
+  font-family: Lato, sans-serif;
   padding: 15rem;
   text-align: center;
 
@@ -30,7 +30,7 @@
 
   h1 {
     color: $ads-primary-main;
-    font-family: Inter, sans-serif;
+    font-family: Lato, sans-serif;
     font-size: $ads-font-size-first;
     font-weight: $ads-font-weight-first;
     line-height: 7.261rem;
@@ -55,80 +55,79 @@
       line-height: 4rem;
     }
   }
+}
 
-  .title {
-    color: $ads-primary-main;
-    font-family: Inter, sans-serif;
+.title {
+  color: $ads-primary-main;
+  font-family: Lato, sans-serif;
+  font-size: $ads-font-size-quarter;
+  font-weight: $ads-font-weight-first;
+  line-height: 3.026rem;
+  margin: 0;
+  margin-bottom: 0.5rem;
+
+  @include respond-to('small-mobile') {
+    font-size: 2.5rem;
+  }
+
+  @include respond-to('medium') {
     font-size: $ads-font-size-quarter;
     font-weight: $ads-font-weight-first;
     line-height: 3.026rem;
-    margin: 0;
-    margin-bottom: 0.5rem;
-
-    @include respond-to('small-mobile') {
-      font-size: 2.5rem;
-    }
-
-    @include respond-to('medium') {
-      font-size: $ads-font-size-quarter;
-      font-weight: $ads-font-weight-first;
-      line-height: 3.026rem;
-    }
-  }
-
-  .message {
-    color: $ads-primary-main;
-    font-family: Inter, sans-serif;
-    font-size: $ads-font-size-fifth;
-    font-weight: $ads-font-weight-first;
-    line-height: 0.908rem;
-    margin: 0.1rem;
-
-    @include respond-to('small-mobile') {
-      font-size: 1rem;
-      line-height: 1.3rem;
-    }
-
-    @include respond-to('medium') {
-      font-size: $ads-font-size-fifth;
-      font-weight: $ads-font-weight-first;
-      line-height: 0.908rem;
-    }
-
-    @include respond-to('extra-large') {
-      font-size: 1rem;
-      line-height: 1.5rem;
-    }
-  }
-
-  .a {
-    color: $ads-primary-main;
-    font-family: Inter, sans-serif;
-    font-size: $ads-font-size-fifth;
-    font-weight: $ads-font-weight-first;
-    line-height: 0.908rem;
-    margin: 0.1rem;
-    text-decoration: none;
-
-    @include respond-to('small') {
-      font-size: 1.25rem;
-    }
-
-    @include respond-to('medium') {
-      font-size: 1.5rem;
-    }
-
-    @include respond-to('large') {
-      font-size: 0.75rem;
-    }
-
-    @include respond-to('extra-large') {
-      font-size: 1rem;
-    }
   }
 }
 
-.server-error {
+.message {
+  color: $ads-primary-main;
+  font-family: Lato, sans-serif;
+  font-size: $ads-font-size-fifth;
+  font-weight: $ads-font-weight-first;
+  line-height: 0.908rem;
+  margin: 0.1rem;
+
+  @include respond-to('small-mobile') {
+    font-size: 1rem;
+    line-height: 1.3rem;
+  }
+
+  @include respond-to('medium') {
+    font-size: $ads-font-size-fifth;
+    font-weight: $ads-font-weight-first;
+    line-height: 0.908rem;
+  }
+
+  @include respond-to('extra-large') {
+    font-size: 2rem;
+    line-height: 2.5rem;
+  }
+}
+
+.link {
+  color: $ads-primary-main;
+  font-family: Lato, sans-serif;
+  font-size: $ads-font-size-fifth;
+  font-weight: $ads-font-weight-first;
+  line-height: 0.908rem;
+  margin: 0.1rem;
+
+  @include respond-to('small') {
+    font-size: 1.25rem;
+  }
+
+  @include respond-to('medium') {
+    font-size: 1.5rem;
+  }
+
+  @include respond-to('large') {
+    font-size: 0.75rem;
+  }
+
+  @include respond-to('extra-large') {
+    font-size: 2rem;
+  }
+}
+
+.serverError {
   @include respond-to('small-mobile') {
     padding: 0;
     padding-top: 12rem;
@@ -147,7 +146,7 @@
   }
 
   h1 {
-    font-family: Inter, sans-serif;
+    font-family: Lato, sans-serif;
     font-size: $ads-font-size-third;
     font-weight: $ads-font-weight-second;
     line-height: 9.682rem;
@@ -173,7 +172,7 @@
   }
 
   .title {
-    font-family: Inter, sans-serif;
+    font-family: Lato, sans-serif;
     font-size: $ads-font-size-quarter;
     font-weight: $ads-font-weight;
     line-height: 3.026rem;
@@ -191,7 +190,7 @@
   }
 
   .message {
-    font-family: Inter, sans-serif;
+    font-family: Lato, sans-serif;
     font-size: $ads-font-size-sixth;
     font-weight: $ads-font-weight-first;
     line-height: 1.134rem;
@@ -208,7 +207,7 @@
     }
 
     @include respond-to('extra-large') {
-      font-size: 1rem;
+      font-size: 2rem;
     }
   }
 }

--- a/src/ui/components/atoms/error-message/ErrorMessage.module.scss
+++ b/src/ui/components/atoms/error-message/ErrorMessage.module.scss
@@ -1,7 +1,7 @@
 @import '../../../../globals/variables';
 @import '../../../../globals/mixins';
 
-.errorMessage {
+.error-message {
   color: $ads-primary-main;
   font-family: Lato, sans-serif;
   padding: 15rem;
@@ -102,32 +102,7 @@
   }
 }
 
-.link {
-  color: $ads-primary-main;
-  font-family: Lato, sans-serif;
-  font-size: $ads-font-size-fifth;
-  font-weight: $ads-font-weight-first;
-  line-height: 0.908rem;
-  margin: 0.1rem;
-
-  @include respond-to('small') {
-    font-size: 1.25rem;
-  }
-
-  @include respond-to('medium') {
-    font-size: 1.5rem;
-  }
-
-  @include respond-to('large') {
-    font-size: 0.75rem;
-  }
-
-  @include respond-to('extra-large') {
-    font-size: 2rem;
-  }
-}
-
-.serverError {
+.server-error {
   @include respond-to('small-mobile') {
     padding: 0;
     padding-top: 12rem;

--- a/src/ui/components/atoms/error-message/ErrorMessage.tsx
+++ b/src/ui/components/atoms/error-message/ErrorMessage.tsx
@@ -1,4 +1,4 @@
-import './ErrorMessage.scss';
+import styles from './ErrorMessage.module.scss';
 import type { IProps } from './types/IProps';
 
 function ErrorMessage(props: IProps) {
@@ -6,16 +6,19 @@ function ErrorMessage(props: IProps) {
   const isServerError = code === 500;
 
   return (
-    <div className={`error-message ${isServerError ? 'server-error' : ''}`}>
+    <div className={`${styles.errorMessage} ${isServerError ? styles.serverError : ''}`}>
       <h1>{code}</h1>
-      <p className="title">{title}</p>
-      <p className="message">{message}</p>
-      <p className="message">
+      <p className={styles.title}>{title}</p>
+      <p className={styles.message}>{message}</p>
+      <p className={styles.message}>
         {messageinit}
-        <a href={redirectTo}>{linkText}</a>
+        <a href={redirectTo} className={styles.a}>
+          {linkText}
+        </a>
         {messagefinish}
       </p>
     </div>
   );
 }
+
 export default ErrorMessage;

--- a/src/ui/components/atoms/error-message/ErrorMessage.tsx
+++ b/src/ui/components/atoms/error-message/ErrorMessage.tsx
@@ -6,7 +6,7 @@ function ErrorMessage(props: IProps) {
   const isServerError = code === 500;
 
   return (
-    <div className={`${styles.errorMessage} ${isServerError ? styles.serverError : ''}`}>
+    <div className={`${styles['error-message']} ${isServerError ? styles['server-error'] : ''}`}>
       <h1>{code}</h1>
       <p className={styles.title}>{title}</p>
       <p className={styles.message}>{message}</p>


### PR DESCRIPTION
Utilizando el nuevo enfoque para aislar los estilos basados en CSS Modules, refactoriza los componentes `SEM-069`y `SEM-070` y modifica sus estilos. Toma como referencia la siguiente PR: [PR #122](https://github.com/Ditmar/OpenScience/pull/122/files).
