### PR TITLE
feat: add Refactor, isolar los estilos de los componentes SEM-036 & SEM-037 [feature/SEM-305]

### DIFF
--- a/src/ui/components/atoms/logo/logo.module.scss
+++ b/src/ui/components/atoms/logo/logo.module.scss
@@ -1,0 +1,89 @@
+@import '../../../../globals/variables';
+@import '../../../../globals/mixins';
+@import '../../../../globals/breakpoints';
+
+.logo-container {
+  border: none;
+
+  @include respond-to('small-mobile') {
+    border-radius: 0 1.688rem 1.688rem 0;
+    height: 3.188rem;
+    margin-left: 0;
+    margin-top: 0;
+    width: 8.125rem;
+  }
+
+  @include respond-to('medium') {
+    border-radius: 0 1.688rem 1.688rem 0;
+    height: 3.188rem;
+    margin-left: 0;
+    margin-top: 0;
+    width: 8.125rem;
+  }
+
+  @include respond-to('large') {
+    border-radius: 0 0 2.563rem 0.8rem;
+    height: 6.1rem;
+    margin-left: 0;
+    margin-top: 0;
+    width: 17.688rem;
+  }
+
+  @include respond-to('extra-large') {
+    border-radius: 0 0 2.563rem 0.8rem;
+    height: 6.1rem;
+    margin-left: 0;
+    margin-top: 0;
+    width: 17.688rem;
+  }
+
+  &--default {
+    background-color: $ads-color-main;
+  }
+
+  &--primary {
+    background-color: $ads-background-main;
+  }
+
+  &--secondary {
+    background-color: $ads-primary-main;
+  }
+}
+
+.logo-image {
+  border: none;
+
+  @include respond-to('small-mobile') {
+    height: 2.063rem;
+    margin: none;
+    margin-left: 0.75rem;
+    padding-left: 0.1rem;
+    padding-top: 0.5rem;
+    width: 6rem;
+  }
+
+  @include respond-to('medium') {
+    height: 2.063rem;
+    margin: none;
+    margin-left: 0.75rem;
+    padding-left: 0.1rem;
+    padding-top: 0.5rem;
+    width: 6rem;
+  }
+
+  @include respond-to('large') {
+    height: 4.813rem;
+    margin: none;
+    margin-left: 3rem;
+    margin-top: 0.3rem;
+    width: 10.75rem;
+  }
+
+  @include respond-to('extra-large') {
+    height: 4.813rem;
+    margin: none;
+    margin-left: 3rem;
+    margin-top: 0.3rem;
+    width: 10.75rem;
+  }
+}

--- a/src/ui/components/atoms/logo/logo.tsx
+++ b/src/ui/components/atoms/logo/logo.tsx
@@ -1,14 +1,14 @@
-import './style.scss';
+import styles from './logo.module.scss';
 import type { IProps } from './types/IProps';
 
 function Logo(props: IProps) {
   const { src, alt, variant = 'primary' } = props;
-  const color = `logo-container--${variant}`;
+  const colorClass = `logo-container--${variant}`;
 
   return (
-    <header className={`logo-container ${color}`}>
+    <header className={`${styles['logo-container']}  ${styles[colorClass]}`}>
       <div>
-        <img src={src} alt={alt} className="logo-image" />
+        <img src={src} alt={alt} className={styles['logo-image']} />
       </div>
       <div />
     </header>

--- a/src/ui/components/atoms/primary-buttons/PrimaryButtons.module.scss
+++ b/src/ui/components/atoms/primary-buttons/PrimaryButtons.module.scss
@@ -1,0 +1,53 @@
+@import '../../../../globals/variables';
+@import '../../../../globals/mixins';
+
+.buttons-primary__button {
+  border: 0.063rem solid transparent;
+  width: 5.75rem;
+
+  @include respond-to('small') {
+    width: 10.313rem;
+  }
+
+  &--primary {
+    background: transparent;
+    border: 0.063rem solid $ads-color-main;
+    color: $ads-color-main;
+
+    &:hover {
+      background: #002a40;
+    }
+  }
+
+  &--secondary {
+    background: $ads-text-main;
+    color: $ads-color-main;
+
+    &:hover {
+      background: $ads-primary-main;
+    }
+  }
+
+  &--tertiary {
+    background: $ads-primary-main;
+    color: $ads-color-main;
+
+    &:hover {
+      background: $ads-secondary-main;
+    }
+  }
+}
+
+.buttons-primary__label {
+  font-family: Roboto, sans-serif;
+  font-size: 0.75rem;
+  font-weight: $ads-font-weight-second;
+  line-height: 0.879rem;
+  text-align: center;
+  text-transform: uppercase;
+
+  @include respond-to('small') {
+    font-size: 1.25rem;
+    line-height: 1.465rem;
+  }
+}

--- a/src/ui/components/atoms/primary-buttons/PrimaryButtons.test.jsx
+++ b/src/ui/components/atoms/primary-buttons/PrimaryButtons.test.jsx
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import PrimaryButtons from './PrimaryButtons.tsx';
+import styles from './PrimaryButtons.module.scss';
 
 describe('Testing VariableButton React Component', () => {
   test('should be rendere INICIAR SESION', () => {
@@ -14,11 +15,12 @@ describe('Testing VariableButton React Component', () => {
     expect(buttonElement).toBeInTheDocument();
   });
   test('should have correct styles class', () => {
-    render(<PrimaryButtons>INICiAR SESION</PrimaryButtons>);
+    render(<PrimaryButtons variant="primary">INICIAR SESION</PrimaryButtons>);
     const buttonElement = screen.getByRole('button');
     const labelElement = screen.getByText(/INICIAR SESION/i);
-    expect(buttonElement).toHaveClass('buttons-primary__button');
-    expect(labelElement).toHaveClass('buttons-primary__label');
+    expect(buttonElement).toHaveClass(styles['buttons-primary__button']);
+    expect(buttonElement).toHaveClass(styles['buttons-primary__button--primary']);
+    expect(labelElement).toHaveClass(styles['buttons-primary__label']);
   });
 
   const createMockFunction = () => {

--- a/src/ui/components/atoms/primary-buttons/PrimaryButtons.tsx
+++ b/src/ui/components/atoms/primary-buttons/PrimaryButtons.tsx
@@ -1,15 +1,19 @@
-import './styles.scss';
+import styles from './PrimaryButtons.module.scss';
 import type { IProps } from './types/IProps';
 
 function PrimaryButtons(props: IProps) {
   const { children, variant, onClick } = props;
+  const buttonClass = `${styles['buttons-primary__button']} ${
+    styles[`buttons-primary__button--${variant}`]
+  }`;
+  const labelClass = styles['buttons-primary__label'];
+
+  console.log('Button class:', buttonClass);
+  console.log('Label class:', labelClass);
   return (
     <div>
-      <button
-        className={`buttons-primary__button buttons-primary__button--${variant}`}
-        onClick={onClick}
-      >
-        <span className={`buttons-primary__label `}>{children}</span>
+      <button className={buttonClass} onClick={onClick}>
+        <span className={labelClass}>{children}</span>
       </button>
     </div>
   );


### PR DESCRIPTION
Utilizando el nuevo enfoque para aislar los estilos basados en CSS Modules, refactoriza los componentes SEM-036 y SEM-037 y modifica sus estilos. Toma como referencia la siguiente PR: [PR #122](https://github.com/Ditmar/OpenScience/pull/122/files).