### PR TITLE
[SEM-311]: Refactor, isolar los estilos de los componentes SEM-054 & SEM-055

### DIFF
--- a/src/ui/components/atoms/article-title/ArticleTitle.module.scss
+++ b/src/ui/components/atoms/article-title/ArticleTitle.module.scss
@@ -1,7 +1,7 @@
 @import '../../../../globals/variables';
 @import '../../../../globals/mixins';
 
-.articleTitle {
+.article-title {
   &__text {
     background: $ads-background-main;
     background-color: transparent;

--- a/src/ui/components/atoms/article-title/ArticleTitle.module.scss
+++ b/src/ui/components/atoms/article-title/ArticleTitle.module.scss
@@ -1,44 +1,46 @@
 @import '../../../../globals/variables';
 @import '../../../../globals/mixins';
 
-.titleText {
-  background: $ads-background-main;
-  background-color: transparent;
-  display: flex;
-  font-family: Roboto, sans-serif;
-  font-size: $ads-size-main;
-  font-weight: $ads-font-weight-bold;
-  letter-spacing: $ads-letter-spacing;
-  line-height: 2rem;
-  padding: 0.265rem;
-
-  @include respond-to('small') {
-    font-size: 1.5em;
-    letter-spacing: 0.075rem;
-    width: 100%;
-  }
-
-  @include respond-to('medium') {
+.articleTitle {
+  &__text {
+    background: $ads-background-main;
+    background-color: transparent;
+    display: flex;
+    font-family: Roboto, sans-serif; 
     font-size: 1.5rem;
+    font-weight: 700;
     letter-spacing: 0.1rem;
-    width: 100%;
+    line-height: 2rem;
+    padding: 0.265rem;
+
+    @include respond-to('small') {
+      font-size: 1.5em;
+      letter-spacing: 0.075rem;
+      width: 100%;
+    }
+
+    @include respond-to('medium') {
+      font-size: 1.5rem;
+      letter-spacing: 0.1rem;
+      width: 100%;
+    }
+
+    @include respond-to('large') {
+      font-size: 1.5rem;
+      letter-spacing: 0.0125rem;
+    }
+
+    @include respond-to('extra-large') {
+      font-size: 1.5rem;
+      letter-spacing: 0.15rem;
+    }
   }
 
-  @include respond-to('large') {
-    font-size: 1.5rem;
-    letter-spacing: 0.0125rem;
+  &__text--primary {
+    color: $ads-primary-main;
   }
 
-  @include respond-to('extra-large') {
-    font-size: 1.5rem;
-    letter-spacing: 0.15rem;
+  &__text--secondary {
+    color: $ads-secondary-main;
   }
-}
-
-.primaryText {
-  color: $ads-primary-main;
-}
-
-.secondaryText {
-  color: $ads-secondary-main;
 }

--- a/src/ui/components/atoms/article-title/ArticleTitle.module.scss
+++ b/src/ui/components/atoms/article-title/ArticleTitle.module.scss
@@ -1,0 +1,44 @@
+@import '../../../../globals/variables';
+@import '../../../../globals/mixins';
+
+.titleText {
+  background: $ads-background-main;
+  background-color: transparent;
+  display: flex;
+  font-family: Roboto, sans-serif;
+  font-size: $ads-size-main;
+  font-weight: $ads-font-weight-bold;
+  letter-spacing: $ads-letter-spacing;
+  line-height: 2rem;
+  padding: 0.265rem;
+
+  @include respond-to('small') {
+    font-size: 1.5em;
+    letter-spacing: 0.075rem;
+    width: 100%;
+  }
+
+  @include respond-to('medium') {
+    font-size: 1.5rem;
+    letter-spacing: 0.1rem;
+    width: 100%;
+  }
+
+  @include respond-to('large') {
+    font-size: 1.5rem;
+    letter-spacing: 0.0125rem;
+  }
+
+  @include respond-to('extra-large') {
+    font-size: 1.5rem;
+    letter-spacing: 0.15rem;
+  }
+}
+
+.primaryText {
+  color: $ads-primary-main;
+}
+
+.secondaryText {
+  color: $ads-secondary-main;
+}

--- a/src/ui/components/atoms/article-title/ArticleTitle.test.tsx
+++ b/src/ui/components/atoms/article-title/ArticleTitle.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import ArticleTitle from './ArticleTitle';
+import styles from './ArticleTitle.module.scss';
 
 describe('ArticleTitle', () => {
   test('title of an article', () => {
@@ -7,21 +8,22 @@ describe('ArticleTitle', () => {
     render(<ArticleTitle title={mockTitle} />);
     expect(screen.getByText(mockTitle)).toBeInTheDocument();
   });
+
   test('title two of an article', () => {
     const mockTitle = 'New title of an article';
     render(<ArticleTitle title={mockTitle} variant="primary" />);
 
     const titleElement = screen.getByText(mockTitle);
-    expect(titleElement).toHaveClass('title-text');
-    expect(titleElement).toHaveClass('primary-text');
+    expect(titleElement).toHaveClass(styles.titleText);
+    expect(titleElement).toHaveClass(styles.primaryText);
   });
 
   test('title three of an article', () => {
-    const mockTitle = 'New totle of an article.';
+    const mockTitle = 'New title of an article';
     render(<ArticleTitle title={mockTitle} variant="secondary" />);
 
     const titleElement = screen.getByText(mockTitle);
-    expect(titleElement).toHaveClass('title-text');
-    expect(titleElement).toHaveClass('secondary-text');
+    expect(titleElement).toHaveClass(styles.titleText);
+    expect(titleElement).toHaveClass(styles.secondaryText);
   });
 });

--- a/src/ui/components/atoms/article-title/ArticleTitle.test.tsx
+++ b/src/ui/components/atoms/article-title/ArticleTitle.test.tsx
@@ -14,8 +14,8 @@ describe('ArticleTitle', () => {
     render(<ArticleTitle title={mockTitle} variant="primary" />);
 
     const titleElement = screen.getByText(mockTitle);
-    expect(titleElement).toHaveClass(styles.articleTitle__text);
-    expect(titleElement).toHaveClass(styles['articleTitle__text--primary']);
+    expect(titleElement).toHaveClass(styles['article-title__text']);
+    expect(titleElement).toHaveClass(styles['article-title__text--primary']);
   });
 
   test('title three of an article', () => {
@@ -23,7 +23,7 @@ describe('ArticleTitle', () => {
     render(<ArticleTitle title={mockTitle} variant="secondary" />);
 
     const titleElement = screen.getByText(mockTitle);
-    expect(titleElement).toHaveClass(styles.articleTitle__text);
-    expect(titleElement).toHaveClass(styles['articleTitle__text--secondary']);
+    expect(titleElement).toHaveClass(styles['article-title__text']);
+    expect(titleElement).toHaveClass(styles['article-title__text--secondary']);
   });
 });

--- a/src/ui/components/atoms/article-title/ArticleTitle.test.tsx
+++ b/src/ui/components/atoms/article-title/ArticleTitle.test.tsx
@@ -26,5 +26,4 @@ describe('ArticleTitle', () => {
     expect(titleElement).toHaveClass(styles.articleTitle__text);
     expect(titleElement).toHaveClass(styles['articleTitle__text--secondary']);
   });
-
 });

--- a/src/ui/components/atoms/article-title/ArticleTitle.test.tsx
+++ b/src/ui/components/atoms/article-title/ArticleTitle.test.tsx
@@ -5,7 +5,7 @@ import styles from './ArticleTitle.module.scss';
 describe('ArticleTitle', () => {
   test('title of an article', () => {
     const mockTitle = 'New title of an article';
-    render(<ArticleTitle title={mockTitle} />);
+    render(<ArticleTitle title={mockTitle} variant="default" />);
     expect(screen.getByText(mockTitle)).toBeInTheDocument();
   });
 
@@ -14,8 +14,8 @@ describe('ArticleTitle', () => {
     render(<ArticleTitle title={mockTitle} variant="primary" />);
 
     const titleElement = screen.getByText(mockTitle);
-    expect(titleElement).toHaveClass(styles.titleText);
-    expect(titleElement).toHaveClass(styles.primaryText);
+    expect(titleElement).toHaveClass(styles.articleTitle__text);
+    expect(titleElement).toHaveClass(styles['articleTitle__text--primary']);
   });
 
   test('title three of an article', () => {
@@ -23,7 +23,7 @@ describe('ArticleTitle', () => {
     render(<ArticleTitle title={mockTitle} variant="secondary" />);
 
     const titleElement = screen.getByText(mockTitle);
-    expect(titleElement).toHaveClass(styles.titleText);
-    expect(titleElement).toHaveClass(styles.secondaryText);
+    expect(titleElement).toHaveClass(styles.articleTitle__text);
+    expect(titleElement).toHaveClass(styles['articleTitle__text--secondary']);
   });
 });

--- a/src/ui/components/atoms/article-title/ArticleTitle.test.tsx
+++ b/src/ui/components/atoms/article-title/ArticleTitle.test.tsx
@@ -26,4 +26,5 @@ describe('ArticleTitle', () => {
     expect(titleElement).toHaveClass(styles.articleTitle__text);
     expect(titleElement).toHaveClass(styles['articleTitle__text--secondary']);
   });
+
 });

--- a/src/ui/components/atoms/article-title/ArticleTitle.tsx
+++ b/src/ui/components/atoms/article-title/ArticleTitle.tsx
@@ -19,4 +19,5 @@ function ArticleTitle({ title, variant }: IProps) {
     </div>
   );
 }
+
 export default ArticleTitle;

--- a/src/ui/components/atoms/article-title/ArticleTitle.tsx
+++ b/src/ui/components/atoms/article-title/ArticleTitle.tsx
@@ -3,14 +3,11 @@ import type { IProps } from './types/IProps';
 
 function ArticleTitle({ title, variant }: IProps) {
   const getTextStyle = () => {
-    if (variant === 'default') {
-      return styles.defaultText;
-    }
     if (variant === 'primary') {
-      return styles.primaryText;
+      return styles['articleTitle__text--primary'];
     }
     if (variant === 'secondary') {
-      return styles.secondaryText;
+      return styles['articleTitle__text--secondary'];
     }
     return '';
   };
@@ -18,9 +15,8 @@ function ArticleTitle({ title, variant }: IProps) {
   const textStyle = getTextStyle();
   return (
     <div className={styles.articleTitle}>
-      <p className={`${styles.titleText} ${textStyle}`}>{title}</p>
+      <p className={`${styles.articleTitle__text} ${textStyle}`}>{title}</p>
     </div>
   );
 }
-
 export default ArticleTitle;

--- a/src/ui/components/atoms/article-title/ArticleTitle.tsx
+++ b/src/ui/components/atoms/article-title/ArticleTitle.tsx
@@ -1,23 +1,24 @@
-import './ArticleTitle.scss';
+import styles from './ArticleTitle.module.scss';
 import type { IProps } from './types/IProps';
 
 function ArticleTitle({ title, variant }: IProps) {
   const getTextStyle = () => {
     if (variant === 'default') {
-      return 'default-text';
+      return styles.defaultText;
     }
     if (variant === 'primary') {
-      return 'primary-text';
+      return styles.primaryText;
     }
     if (variant === 'secondary') {
-      return 'secondary-text';
+      return styles.secondaryText;
     }
     return '';
   };
+
   const textStyle = getTextStyle();
   return (
-    <div className="article-title">
-      <p className={`title-text ${textStyle}`}>{title}</p>
+    <div className={styles.articleTitle}>
+      <p className={`${styles.titleText} ${textStyle}`}>{title}</p>
     </div>
   );
 }

--- a/src/ui/components/atoms/article-title/ArticleTitle.tsx
+++ b/src/ui/components/atoms/article-title/ArticleTitle.tsx
@@ -4,18 +4,18 @@ import type { IProps } from './types/IProps';
 function ArticleTitle({ title, variant }: IProps) {
   const getTextStyle = () => {
     if (variant === 'primary') {
-      return styles['articleTitle__text--primary'];
+      return styles['article-title__text--primary'];
     }
     if (variant === 'secondary') {
-      return styles['articleTitle__text--secondary'];
+      return styles['article-title__text--secondary'];
     }
     return '';
   };
 
   const textStyle = getTextStyle();
   return (
-    <div className={styles.articleTitle}>
-      <p className={`${styles.articleTitle__text} ${textStyle}`}>{title}</p>
+    <div className={styles['article-title']}>
+      <p className={`${styles['article-title__text']} ${textStyle}`}>{title}</p>
     </div>
   );
 }

--- a/src/ui/components/atoms/label-date/LabelDate.module.scss
+++ b/src/ui/components/atoms/label-date/LabelDate.module.scss
@@ -1,0 +1,29 @@
+@import '../../../../globals/breakpoints';
+@import '../../../../globals/fonts';
+@import '../../../../globals/mixins';
+@import '../../../../globals/variables';
+
+.labeldate {
+  color: $ads-text-secondary;
+  font-family: Lato, Arial, Helvetica, sans-serif;
+  font-size: $ads-font-size-sixth;
+  font-weight: $ads-font-size-first;
+  line-height: $ads-line-height-default;
+  width: fit-content;
+
+  &:hover {
+    color: $ads-text-main-hover;
+  }
+
+  @include respond-to('small') {
+    font-size: 1rem;
+  }
+
+  @include respond-to('medium') {
+    font-size: $ads-font-size-sixth;
+  }
+
+  @include respond-to('large') {
+    font-size: 1rem;
+  }
+}

--- a/src/ui/components/atoms/label-date/LabelDate.test.jsx
+++ b/src/ui/components/atoms/label-date/LabelDate.test.jsx
@@ -1,14 +1,15 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import LabelDate from './LabelDate.tsx';
+import styles from './LabelDate.module.scss';
 
 describe('Testing React LabelDate Component', () => {
   test('Must render Label Date 1', () => {
     render(<LabelDate date={new Date(2022, 0, 5)} />);
     const labelElement = screen.getByText('Enero 5 | 2022');
     expect(labelElement).toBeInTheDocument();
-    expect(labelElement).toHaveClass('labeldate');
-    expect(labelElement).not.toHaveClass('labeldate--overflow');
+    expect(labelElement).toHaveClass(styles.labeldate);
+    expect(labelElement).not.toHaveClass(styles['labeldate--overflow']);
     expect(labelElement.dataset.iso).toBe('2022-01-05');
   });
 
@@ -16,8 +17,8 @@ describe('Testing React LabelDate Component', () => {
     render(<LabelDate date={new Date(2018, 3, 20)} />);
     const labelElement = screen.getByText('Abril 20 | 2018');
     expect(labelElement).toBeInTheDocument();
-    expect(labelElement).toHaveClass('labeldate');
-    expect(labelElement).not.toHaveClass('labeldate--overflow');
+    expect(labelElement).toHaveClass(styles.labeldate);
+    expect(labelElement).not.toHaveClass(styles['labeldate--overflow']);
     expect(labelElement.dataset.iso).toBe('2018-04-20');
   });
 
@@ -25,8 +26,8 @@ describe('Testing React LabelDate Component', () => {
     render(<LabelDate date={new Date(2022, 11, 1)} />);
     const labelElement = screen.getByText('Diciembre 1 | 2022');
     expect(labelElement).toBeInTheDocument();
-    expect(labelElement).toHaveClass('labeldate');
-    expect(labelElement).not.toHaveClass('labeldate--overflow');
+    expect(labelElement).toHaveClass(styles.labeldate);
+    expect(labelElement).not.toHaveClass(styles['labeldate--overflow']);
     expect(labelElement.dataset.iso).toBe('2022-12-01');
   });
 });

--- a/src/ui/components/atoms/label-date/LabelDate.tsx
+++ b/src/ui/components/atoms/label-date/LabelDate.tsx
@@ -1,7 +1,7 @@
-import './LabelDate.scss';
 import React from 'react';
 import type { IProps } from './types/IProps';
 import { formatDate } from './utils/dateFormatter';
+import styles from './LabelDate.module.scss';
 
 function LabelDate({ date, overflow = false }: IProps) {
   if (!(date instanceof Date)) {
@@ -9,7 +9,7 @@ function LabelDate({ date, overflow = false }: IProps) {
   }
   const formattedDate = formatDate(date);
   const isoDate = date.toISOString().split('T')[0];
-  const className = `labeldate${overflow ? ' labeldate--overflow' : ''}`;
+  const className = `${styles.labeldate}${overflow ? ` ${styles['labeldate--overflow']}` : ''}`;
   return (
     <p className={className} data-iso={isoDate}>
       {formattedDate}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1344,11 +1344,6 @@
   resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.20.2.tgz#a70f4ac11c6a1dfc18b8bbb13284155d933b9537"
   integrity sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==
 
-"@esbuild/aix-ppc64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz#c7184a326533fcdf1b8ee0733e21c713b975575f"
-  integrity sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==
-
 "@esbuild/android-arm64@0.19.12":
   version "0.19.12"
   resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.19.12.tgz#7ad65a36cfdb7e0d429c353e00f680d737c2aed4"
@@ -1358,11 +1353,6 @@
   version "0.20.2"
   resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.20.2.tgz#db1c9202a5bc92ea04c7b6840f1bbe09ebf9e6b9"
   integrity sha512-mRzjLacRtl/tWU0SvD8lUEwb61yP9cqQo6noDZP/O8VkwafSYwZ4yWy24kan8jE/IMERpYncRt2dw438LP3Xmg==
-
-"@esbuild/android-arm64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz#09d9b4357780da9ea3a7dfb833a1f1ff439b4052"
-  integrity sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==
 
 "@esbuild/android-arm@0.15.18":
   version "0.15.18"
@@ -1379,11 +1369,6 @@
   resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.20.2.tgz#3b488c49aee9d491c2c8f98a909b785870d6e995"
   integrity sha512-t98Ra6pw2VaDhqNWO2Oph2LXbz/EJcnLmKLGBJwEwXX/JAN83Fym1rU8l0JUWK6HkIbWONCSSatf4sf2NBRx/w==
 
-"@esbuild/android-arm@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.21.5.tgz#9b04384fb771926dfa6d7ad04324ecb2ab9b2e28"
-  integrity sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==
-
 "@esbuild/android-x64@0.19.12":
   version "0.19.12"
   resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.19.12.tgz#cb13e2211282012194d89bf3bfe7721273473b3d"
@@ -1393,11 +1378,6 @@
   version "0.20.2"
   resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.20.2.tgz#3b1628029e5576249d2b2d766696e50768449f98"
   integrity sha512-btzExgV+/lMGDDa194CcUQm53ncxzeBrWJcncOBxuC6ndBkKxnHdFJn86mCIgTELsooUmwUm9FkhSp5HYu00Rg==
-
-"@esbuild/android-x64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.21.5.tgz#29918ec2db754cedcb6c1b04de8cd6547af6461e"
-  integrity sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==
 
 "@esbuild/darwin-arm64@0.19.12":
   version "0.19.12"
@@ -1409,11 +1389,6 @@
   resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.20.2.tgz#6e8517a045ddd86ae30c6608c8475ebc0c4000bb"
   integrity sha512-4J6IRT+10J3aJH3l1yzEg9y3wkTDgDk7TSDFX+wKFiWjqWp/iCfLIYzGyasx9l0SAFPT1HwSCR+0w/h1ES/MjA==
 
-"@esbuild/darwin-arm64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz#e495b539660e51690f3928af50a76fb0a6ccff2a"
-  integrity sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==
-
 "@esbuild/darwin-x64@0.19.12":
   version "0.19.12"
   resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.19.12.tgz#e37d9633246d52aecf491ee916ece709f9d5f4cd"
@@ -1423,11 +1398,6 @@
   version "0.20.2"
   resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.20.2.tgz#90ed098e1f9dd8a9381695b207e1cff45540a0d0"
   integrity sha512-tBcXp9KNphnNH0dfhv8KYkZhjc+H3XBkF5DKtswJblV7KlT9EI2+jeA8DgBjp908WEuYll6pF+UStUCfEpdysA==
-
-"@esbuild/darwin-x64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz#c13838fa57372839abdddc91d71542ceea2e1e22"
-  integrity sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==
 
 "@esbuild/freebsd-arm64@0.19.12":
   version "0.19.12"
@@ -1439,11 +1409,6 @@
   resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.20.2.tgz#d71502d1ee89a1130327e890364666c760a2a911"
   integrity sha512-d3qI41G4SuLiCGCFGUrKsSeTXyWG6yem1KcGZVS+3FYlYhtNoNgYrWcvkOoaqMhwXSMrZRl69ArHsGJ9mYdbbw==
 
-"@esbuild/freebsd-arm64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz#646b989aa20bf89fd071dd5dbfad69a3542e550e"
-  integrity sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==
-
 "@esbuild/freebsd-x64@0.19.12":
   version "0.19.12"
   resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.19.12.tgz#37a693553d42ff77cd7126764b535fb6cc28a11c"
@@ -1453,11 +1418,6 @@
   version "0.20.2"
   resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.20.2.tgz#aa5ea58d9c1dd9af688b8b6f63ef0d3d60cea53c"
   integrity sha512-d+DipyvHRuqEeM5zDivKV1KuXn9WeRX6vqSqIDgwIfPQtwMP4jaDsQsDncjTDDsExT4lR/91OLjRo8bmC1e+Cw==
-
-"@esbuild/freebsd-x64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz#aa615cfc80af954d3458906e38ca22c18cf5c261"
-  integrity sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==
 
 "@esbuild/linux-arm64@0.19.12":
   version "0.19.12"
@@ -1469,11 +1429,6 @@
   resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.20.2.tgz#055b63725df678379b0f6db9d0fa85463755b2e5"
   integrity sha512-9pb6rBjGvTFNira2FLIWqDk/uaf42sSyLE8j1rnUpuzsODBq7FvpwHYZxQ/It/8b+QOS1RYfqgGFNLRI+qlq2A==
 
-"@esbuild/linux-arm64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz#70ac6fa14f5cb7e1f7f887bcffb680ad09922b5b"
-  integrity sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==
-
 "@esbuild/linux-arm@0.19.12":
   version "0.19.12"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.19.12.tgz#207ecd982a8db95f7b5279207d0ff2331acf5eef"
@@ -1484,11 +1439,6 @@
   resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.20.2.tgz#76b3b98cb1f87936fbc37f073efabad49dcd889c"
   integrity sha512-VhLPeR8HTMPccbuWWcEUD1Az68TqaTYyj6nfE4QByZIQEQVWBB8vup8PpR7y1QHL3CpcF6xd5WVBU/+SBEvGTg==
 
-"@esbuild/linux-arm@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz#fc6fd11a8aca56c1f6f3894f2bea0479f8f626b9"
-  integrity sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==
-
 "@esbuild/linux-ia32@0.19.12":
   version "0.19.12"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.19.12.tgz#d0d86b5ca1562523dc284a6723293a52d5860601"
@@ -1498,11 +1448,6 @@
   version "0.20.2"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.20.2.tgz#c0e5e787c285264e5dfc7a79f04b8b4eefdad7fa"
   integrity sha512-o10utieEkNPFDZFQm9CoP7Tvb33UutoJqg3qKf1PWVeeJhJw0Q347PxMvBgVVFgouYLGIhFYG0UGdBumROyiig==
-
-"@esbuild/linux-ia32@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz#3271f53b3f93e3d093d518d1649d6d68d346ede2"
-  integrity sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==
 
 "@esbuild/linux-loong64@0.15.18":
   version "0.15.18"
@@ -1519,11 +1464,6 @@
   resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.20.2.tgz#a6184e62bd7cdc63e0c0448b83801001653219c5"
   integrity sha512-PR7sp6R/UC4CFVomVINKJ80pMFlfDfMQMYynX7t1tNTeivQ6XdX5r2XovMmha/VjR1YN/HgHWsVcTRIMkymrgQ==
 
-"@esbuild/linux-loong64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz#ed62e04238c57026aea831c5a130b73c0f9f26df"
-  integrity sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==
-
 "@esbuild/linux-mips64el@0.19.12":
   version "0.19.12"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.19.12.tgz#4ddebd4e6eeba20b509d8e74c8e30d8ace0b89ec"
@@ -1533,11 +1473,6 @@
   version "0.20.2"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.20.2.tgz#d08e39ce86f45ef8fc88549d29c62b8acf5649aa"
   integrity sha512-4BlTqeutE/KnOiTG5Y6Sb/Hw6hsBOZapOVF6njAESHInhlQAghVVZL1ZpIctBOoTFbQyGW+LsVYZ8lSSB3wkjA==
-
-"@esbuild/linux-mips64el@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz#e79b8eb48bf3b106fadec1ac8240fb97b4e64cbe"
-  integrity sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==
 
 "@esbuild/linux-ppc64@0.19.12":
   version "0.19.12"
@@ -1549,11 +1484,6 @@
   resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.20.2.tgz#8d252f0b7756ffd6d1cbde5ea67ff8fd20437f20"
   integrity sha512-rD3KsaDprDcfajSKdn25ooz5J5/fWBylaaXkuotBDGnMnDP1Uv5DLAN/45qfnf3JDYyJv/ytGHQaziHUdyzaAg==
 
-"@esbuild/linux-ppc64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz#5f2203860a143b9919d383ef7573521fb154c3e4"
-  integrity sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==
-
 "@esbuild/linux-riscv64@0.19.12":
   version "0.19.12"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.19.12.tgz#11bc0698bf0a2abf8727f1c7ace2112612c15adf"
@@ -1563,11 +1493,6 @@
   version "0.20.2"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.20.2.tgz#19f6dcdb14409dae607f66ca1181dd4e9db81300"
   integrity sha512-snwmBKacKmwTMmhLlz/3aH1Q9T8v45bKYGE3j26TsaOVtjIag4wLfWSiZykXzXuE1kbCE+zJRmwp+ZbIHinnVg==
-
-"@esbuild/linux-riscv64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz#07bcafd99322d5af62f618cb9e6a9b7f4bb825dc"
-  integrity sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==
 
 "@esbuild/linux-s390x@0.19.12":
   version "0.19.12"
@@ -1579,11 +1504,6 @@
   resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.20.2.tgz#3c830c90f1a5d7dd1473d5595ea4ebb920988685"
   integrity sha512-wcWISOobRWNm3cezm5HOZcYz1sKoHLd8VL1dl309DiixxVFoFe/o8HnwuIwn6sXre88Nwj+VwZUvJf4AFxkyrQ==
 
-"@esbuild/linux-s390x@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz#b7ccf686751d6a3e44b8627ababc8be3ef62d8de"
-  integrity sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==
-
 "@esbuild/linux-x64@0.19.12":
   version "0.19.12"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.19.12.tgz#5f37cfdc705aea687dfe5dfbec086a05acfe9c78"
@@ -1593,11 +1513,6 @@
   version "0.20.2"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.20.2.tgz#86eca35203afc0d9de0694c64ec0ab0a378f6fff"
   integrity sha512-1MdwI6OOTsfQfek8sLwgyjOXAu+wKhLEoaOLTjbijk6E2WONYpH9ZU2mNtR+lZ2B4uwr+usqGuVfFT9tMtGvGw==
-
-"@esbuild/linux-x64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz#6d8f0c768e070e64309af8004bb94e68ab2bb3b0"
-  integrity sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==
 
 "@esbuild/netbsd-x64@0.19.12":
   version "0.19.12"
@@ -1609,11 +1524,6 @@
   resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.20.2.tgz#e771c8eb0e0f6e1877ffd4220036b98aed5915e6"
   integrity sha512-K8/DhBxcVQkzYc43yJXDSyjlFeHQJBiowJ0uVL6Tor3jGQfSGHNNJcWxNbOI8v5k82prYqzPuwkzHt3J1T1iZQ==
 
-"@esbuild/netbsd-x64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz#bbe430f60d378ecb88decb219c602667387a6047"
-  integrity sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==
-
 "@esbuild/openbsd-x64@0.19.12":
   version "0.19.12"
   resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.19.12.tgz#306c0acbdb5a99c95be98bdd1d47c916e7dc3ff0"
@@ -1623,11 +1533,6 @@
   version "0.20.2"
   resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.20.2.tgz#9a795ae4b4e37e674f0f4d716f3e226dd7c39baf"
   integrity sha512-eMpKlV0SThJmmJgiVyN9jTPJ2VBPquf6Kt/nAoo6DgHAoN57K15ZghiHaMvqjCye/uU4X5u3YSMgVBI1h3vKrQ==
-
-"@esbuild/openbsd-x64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz#99d1cf2937279560d2104821f5ccce220cb2af70"
-  integrity sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==
 
 "@esbuild/sunos-x64@0.19.12":
   version "0.19.12"
@@ -1639,11 +1544,6 @@
   resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.20.2.tgz#7df23b61a497b8ac189def6e25a95673caedb03f"
   integrity sha512-2UyFtRC6cXLyejf/YEld4Hajo7UHILetzE1vsRcGL3earZEW77JxrFjH4Ez2qaTiEfMgAXxfAZCm1fvM/G/o8w==
 
-"@esbuild/sunos-x64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz#08741512c10d529566baba837b4fe052c8f3487b"
-  integrity sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==
-
 "@esbuild/win32-arm64@0.19.12":
   version "0.19.12"
   resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.19.12.tgz#773bdbaa1971b36db2f6560088639ccd1e6773ae"
@@ -1653,11 +1553,6 @@
   version "0.20.2"
   resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.20.2.tgz#f1ae5abf9ca052ae11c1bc806fb4c0f519bacf90"
   integrity sha512-GRibxoawM9ZCnDxnP3usoUDO9vUkpAxIIZ6GQI+IlVmr5kP3zUq+l17xELTHMWTWzjxa2guPNyrpq1GWmPvcGQ==
-
-"@esbuild/win32-arm64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz#675b7385398411240735016144ab2e99a60fc75d"
-  integrity sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==
 
 "@esbuild/win32-ia32@0.19.12":
   version "0.19.12"
@@ -1669,11 +1564,6 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.20.2.tgz#241fe62c34d8e8461cd708277813e1d0ba55ce23"
   integrity sha512-HfLOfn9YWmkSKRQqovpnITazdtquEW8/SoHW7pWpuEeguaZI4QnCRW6b+oZTztdBnZOS2hqJ6im/D5cPzBTTlQ==
 
-"@esbuild/win32-ia32@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz#1bfc3ce98aa6ca9a0969e4d2af72144c59c1193b"
-  integrity sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==
-
 "@esbuild/win32-x64@0.19.12":
   version "0.19.12"
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.19.12.tgz#c57c8afbb4054a3ab8317591a0b7320360b444ae"
@@ -1683,11 +1573,6 @@
   version "0.20.2"
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.20.2.tgz#9c907b21e30a52db959ba4f80bb01a0cc403d5cc"
   integrity sha512-N49X4lJX27+l9jbLKSqZ6bKNjzQvHaT8IIFUy+YIqmXQdjYCToGWwOItDrfby14c78aDd5NHQl29xingXfCdLQ==
-
-"@esbuild/win32-x64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz#acad351d582d157bb145535db2a6ff53dd514b5c"
-  integrity sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==
 
 "@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.4.0":
   version "4.4.0"
@@ -5635,7 +5520,7 @@ esbuild@^0.15.16:
     esbuild-windows-64 "0.15.18"
     esbuild-windows-arm64 "0.15.18"
 
-"esbuild@^0.18.0 || ^0.19.0 || ^0.20.0":
+"esbuild@^0.18.0 || ^0.19.0 || ^0.20.0", esbuild@^0.20.1:
   version "0.20.2"
   resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.20.2.tgz#9d6b2386561766ee6b5a55196c6d766d28c87ea1"
   integrity sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==
@@ -5692,35 +5577,6 @@ esbuild@^0.19.6:
     "@esbuild/win32-arm64" "0.19.12"
     "@esbuild/win32-ia32" "0.19.12"
     "@esbuild/win32-x64" "0.19.12"
-
-esbuild@^0.21.3:
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.21.5.tgz#9ca301b120922959b766360d8ac830da0d02997d"
-  integrity sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==
-  optionalDependencies:
-    "@esbuild/aix-ppc64" "0.21.5"
-    "@esbuild/android-arm" "0.21.5"
-    "@esbuild/android-arm64" "0.21.5"
-    "@esbuild/android-x64" "0.21.5"
-    "@esbuild/darwin-arm64" "0.21.5"
-    "@esbuild/darwin-x64" "0.21.5"
-    "@esbuild/freebsd-arm64" "0.21.5"
-    "@esbuild/freebsd-x64" "0.21.5"
-    "@esbuild/linux-arm" "0.21.5"
-    "@esbuild/linux-arm64" "0.21.5"
-    "@esbuild/linux-ia32" "0.21.5"
-    "@esbuild/linux-loong64" "0.21.5"
-    "@esbuild/linux-mips64el" "0.21.5"
-    "@esbuild/linux-ppc64" "0.21.5"
-    "@esbuild/linux-riscv64" "0.21.5"
-    "@esbuild/linux-s390x" "0.21.5"
-    "@esbuild/linux-x64" "0.21.5"
-    "@esbuild/netbsd-x64" "0.21.5"
-    "@esbuild/openbsd-x64" "0.21.5"
-    "@esbuild/sunos-x64" "0.21.5"
-    "@esbuild/win32-arm64" "0.21.5"
-    "@esbuild/win32-ia32" "0.21.5"
-    "@esbuild/win32-x64" "0.21.5"
 
 escalade@^3.1.1, escalade@^3.1.2:
   version "3.1.2"


### PR DESCRIPTION
Utilizando el nuevo enfoque para aislar los estilos basados en CSS Modules, refactoriza los componentes SEM-054y SEM-055 y modifica sus estilos. Toma como referencia la siguiente PR: [PR #122](https://github.com/Ditmar/OpenScience/pull/122/files).
ANTES:

![img](https://github.com/Ditmar/OpenScience/assets/150865355/c3cd617c-5a37-43b3-9e42-efc1793ce1df)

![img2](https://github.com/Ditmar/OpenScience/assets/150865355/7f188679-7e67-4488-99cb-9060b31fb7f0)

DESPUES:
![img3](https://github.com/Ditmar/OpenScience/assets/150865355/0d952ff0-c8c2-4ecc-b09f-cf950e508b11)

![img4](https://github.com/Ditmar/OpenScience/assets/150865355/0e0369e7-8dd8-4302-b5cd-42de724858e8)
