### PR TITLE
[SEM-002]: Lupa de búqueda

### DIFF
--- a/src/ui/components/molecules/search-magnifying-glass/SearchMagnifyingGlass.scss
+++ b/src/ui/components/molecules/search-magnifying-glass/SearchMagnifyingGlass.scss
@@ -1,0 +1,51 @@
+@import '../../../../globals/fonts';
+@import '../../../../globals/mixins';
+@import '../../../../globals/variables';
+
+.option-search {
+  align-items: center;
+  justify-content: space-between;
+  left: 1rem;
+  padding: 0.625rem 1.875rem; 
+  position: relative;
+  right: 1rem;
+  top: 1rem;
+
+  &__items {
+    align-items: center;
+    display: flex;
+    justify-content: space-between;
+    left: 15rem;
+    position: absolute;
+    right: 15rem;
+  }
+
+  .navbar {
+    @include respond-to('small-mobile') {
+      height: 3rem;
+      width: 2rem;
+    }
+
+    @include respond-to('medium') {
+      width: 7rem;
+    }
+
+    @include respond-to('large') {
+      width: 8rem;
+    }
+
+    @include respond-to('extra-large') {
+      width: 10rem;
+    }
+  }
+
+  .option-magnifying-glass {
+    align-items: center;
+    cursor: pointer;
+    display: flex;
+    height: 1.875rem; 
+    justify-content: center;
+    position: relative;
+    width: 1.875rem; 
+  }  
+}

--- a/src/ui/components/molecules/search-magnifying-glass/SearchMagnifyingGlass.stories.tsx
+++ b/src/ui/components/molecules/search-magnifying-glass/SearchMagnifyingGlass.stories.tsx
@@ -1,0 +1,13 @@
+import type { StoryObj, Meta } from '@storybook/react';
+import SearchMagnifyingGlass from './SearchMagnifyingGlass';
+
+const meta: Meta<typeof SearchMagnifyingGlass> = {
+  title: 'ui/components/molecules/search-magnifying-glass',
+  component: SearchMagnifyingGlass,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/ui/components/molecules/search-magnifying-glass/SearchMagnifyingGlass.test.tsx
+++ b/src/ui/components/molecules/search-magnifying-glass/SearchMagnifyingGlass.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react';
+import SearchMagnifyingGlass from './SearchMagnifyingGlass';
+
+describe('SearchMagnifyingGlass Component', () => {
+  test('should render MagnifyingGlass', () => {
+    render(<SearchMagnifyingGlass />);
+    const magnifyingGlass = screen.getByTestId('button__glass');
+    expect(magnifyingGlass).toBeInTheDocument();
+  });
+
+  test('menu navbar should not be visible initially', () => {
+    render(<SearchMagnifyingGlass />);
+    expect(screen.queryByText('/Articulos/')).not.toBeInTheDocument();
+    expect(screen.queryByText('/Inicio/')).not.toBeInTheDocument();
+    expect(screen.queryByText('/Volumenes/')).not.toBeInTheDocument();
+  });
+});

--- a/src/ui/components/molecules/search-magnifying-glass/SearchMagnifyingGlass.tsx
+++ b/src/ui/components/molecules/search-magnifying-glass/SearchMagnifyingGlass.tsx
@@ -1,0 +1,26 @@
+import './SearchMagnifyingGlass.scss';
+import type { IProps } from './types/IProps';
+import Navbar from '../../atoms/navbar/Navbar';
+import MagnifyingGlass from '../magnifying-glass/MagnifyingGlass';
+import ArticlesIcon from '../../../../assets/icons/article.svg?raw';
+import StartIcon from '../../../../assets/icons/start.svg?raw';
+import VolumesIcon from '../../../../assets/icons/volumes.svg?raw';
+import glass from '../../../../assets/icons/magnifyingglass.svg?raw';
+
+function SearchMagnifyingGlass({ variant = 'solid', onClick }: IProps) {
+  return (
+    <div className="option-search">
+      <div className="option-search__items">
+        <Navbar icon={ArticlesIcon}>ARTÍCULOS</Navbar>
+        <Navbar icon={StartIcon}>INICIO</Navbar>
+        <Navbar icon={VolumesIcon}>VOLUMENES</Navbar>
+      </div>
+      <MagnifyingGlass icon={glass} variant={variant} onClick={onClick} aria-label="Menu">
+        BUSCAR
+      </MagnifyingGlass>
+      <div className="option-magnifyingGlass" role="menu" />
+    </div>
+  );
+}
+
+export default SearchMagnifyingGlass;

--- a/src/ui/components/molecules/search-magnifying-glass/types/IProps.ts
+++ b/src/ui/components/molecules/search-magnifying-glass/types/IProps.ts
@@ -1,0 +1,4 @@
+export interface IProps {
+  variant?: 'solid';
+  onClick: () => void;
+}


### PR DESCRIPTION
Como usuario, quiero hacer clic en un icono de lupa para desplegar un campo de búsqueda, para que pueda buscar contenido en la aplicación de manera fácil y rápida. Ademas de mostrar el logo de la aplicación en la parte superior.
![Captura de pantalla 2024-07-04 005601](https://github.com/Ditmar/OpenScience/assets/170877031/08214b3f-b380-447d-9572-0357930eaf25)
