### PR TITLE
Add grid for feature/FRONTEND-228

### DIFF
--- a/src/GridMobile/GridMobile.scss
+++ b/src/GridMobile/GridMobile.scss
@@ -1,0 +1,23 @@
+@import '../globals/variables';
+
+.container {
+  box-sizing: border-box;
+  margin: 0 auto;
+  max-width: $ads-gridmobile-container-size;
+  padding: 0 $ads-gridmobile-margin;
+  width: 100%;
+}
+
+.auto-grid {
+  display: grid;
+  gap: $ads-gridmobile-gutter;
+  grid-template-columns: repeat($ads-gridmobile-columns, 1fr);
+}
+
+.grid-item {
+  background-color: $ads-gridmobile-item-bg;
+  border: 1px solid #999;
+  font-size: 14px;
+  padding: 12px 0;
+  text-align: center;
+}

--- a/src/GridMobile/GridMobile.tsx
+++ b/src/GridMobile/GridMobile.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import './GridMobile.scss';
+
+function GridMobile(): JSX.Element {
+  return (
+    <div className="container">
+      <div className="auto-grid">
+        {Array.from({ length: 4 }, (_, idx) => (
+          <div className="grid-item" key={`col-${String(idx + 1)}`}>
+            Col {String(idx + 1)}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default GridMobile;

--- a/src/globals/_variables.scss
+++ b/src/globals/_variables.scss
@@ -54,3 +54,8 @@ $ads-gradient-violet-rose: linear-gradient(45deg, #9627fc 0%, #fbc4d2 100%);
 $ads-gradient-pink-blossom: linear-gradient(45deg, #ff5886 0%, #ffb6fc 100%);
 $ads-gradient-sky-magenta: linear-gradient(45deg, #8cd7f7 0%, #f674f9 100%);
 $ads-gradient-neon-lime: linear-gradient(45deg, #a9ffdb 0%, #17d970 100%);
+$ads-gridmobile-columns: 4;
+$ads-gridmobile-container-size: 398px;
+$ads-gridmobile-gutter: 16px;
+$ads-gridmobile-margin: 16px;
+$ads-gridmobile-item-bg: #ccc;


### PR DESCRIPTION
Issue 4: Implementar Grid para Mobile (430px - Fluid) #228

Se agrega un sistema de grillas para dispositivos móviles con contenedor de 398px, márgenes de 16px y 4 columnas con gutter de 16px, optimizando el diseño para pantallas pequeñas como iPhone 14 y 15 Pro Max.


