### PR TITLE
add GridMovile

### DIFF
--- a/src/GridMobile/GridMobile.scss
+++ b/src/GridMobile/GridMobile.scss
@@ -1,0 +1,105 @@
+@import '../globals/variables';
+@import '../globals/breakpoints';
+
+@mixin respond-to-xs {
+  @media (width <= 576px) {
+    @content;
+  }
+}
+
+@mixin respond-to-sm {
+  @media (width <= 768px) {
+    @content;
+  }
+}
+
+@mixin respond-to-md {
+  @media (width <= 992px) {
+    @content;
+  }
+}
+
+@mixin respond-to-lg {
+  @media (width <= 1200px) {
+    @content;
+  }
+}
+
+.container {
+  margin-left: auto;
+  margin-right: auto;
+  max-width: 1200px;
+  padding: 0;
+  width: 100%;
+}
+
+.auto-grid {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(12, minmax(78px, 1fr));
+}
+
+.grid-item {
+  align-items: center;
+  background-color: transparent;
+  border: none;
+  color: transparent;
+  display: flex;
+  font-weight: bold;
+  justify-content: center;
+  min-height: 50px;
+  padding: 12px;
+  text-align: center;
+}
+
+@for $i from 1 through 12 {
+  .col-#{$i} {
+    grid-column: span $i;
+  }
+}
+
+@include respond-to-lg {
+  @for $i from 1 through 12 {
+    .col-lg-#{$i} {
+      grid-column: span $i !important;
+    }
+  }
+}
+
+@include respond-to-md {
+  @for $i from 1 through 12 {
+    .col-md-#{$i} {
+      grid-column: span $i !important;
+    }
+  }
+}
+
+@include respond-to-sm {
+  @for $i from 1 through 12 {
+    .col-sm-#{$i} {
+      grid-column: span $i !important;
+    }
+  }
+}
+
+@include respond-to-xs {
+  @for $i from 1 through 12 {
+    .col-xs-#{$i} {
+      grid-column: span $i !important;
+    }
+  }
+}
+
+@media (max-width: 430px) {
+  .container {
+    max-width: 398px;
+    padding-left: 16px;
+    padding-right: 16px;
+  }
+
+  .auto-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 16px;
+  }
+}

--- a/src/GridMobile/GridMobile.scss
+++ b/src/GridMobile/GridMobile.scss
@@ -90,7 +90,7 @@
   }
 }
 
-@media (max-width: 430px) {
+@media (width <= 430px) {
   .container {
     max-width: 398px;
     padding-left: 16px;
@@ -99,7 +99,7 @@
 
   .auto-grid {
     display: grid;
-    grid-template-columns: repeat(4, 1fr);
     gap: 16px;
+    grid-template-columns: repeat(4, 1fr);
   }
 }

--- a/src/GridMobile/GridMobile.tsx
+++ b/src/GridMobile/GridMobile.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import './GridMobile.scss';
+
+interface Props {
+  children: React.ReactNode;
+}
+
+function GridMobile({ children }: Props) {
+  return (
+    <div className="container">
+      <div className="auto-grid">{children}</div>
+    </div>
+  );
+}
+
+export default GridMobile;
+
+

--- a/src/GridMobile/GridMobile.tsx
+++ b/src/GridMobile/GridMobile.tsx
@@ -14,5 +14,3 @@ function GridMobile({ children }: Props) {
 }
 
 export default GridMobile;
-
-

--- a/src/layouts/GridMobile/GridMobile.scss
+++ b/src/layouts/GridMobile/GridMobile.scss
@@ -1,0 +1,57 @@
+// Importar variables globales y puntos de ruptura (breakpoints)
+@import '../../globals/variables';
+@import './breakpoints-gridmobile.scss';
+
+
+@mixin respond-to-mobile($breakpoint) {
+  @if map-has-key($ads-mobile-breakpoints, $breakpoint) {
+    @media (max-width: map-get($ads-mobile-breakpoints, $breakpoint)) {
+      @content;
+    }
+  } 
+  
+  @else {
+    @warn #{$breakpoint};
+  }
+}
+
+.container-mobile {
+  box-sizing: border-box;
+  margin-left: auto;
+  margin-right: auto;
+  max-width: 398px;
+  padding-left: 16px;
+  padding-right: 16px;
+  width: 100%;
+}
+
+.grid-mobile {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(4, 1fr);
+}
+
+.grid-item-mobile {
+  align-items: center;
+  background-color: transparent;
+  border: 1px dashed #ccc;
+  box-sizing: border-box;
+  color: $ads-color-dark;
+  display: flex;
+  justify-content: center;
+  min-height: 50px;
+  text-align: center;
+  width: 100%;
+}
+
+@for $i from 1 through 4 {
+  .col-mb-#{$i} {
+    grid-column: span $i;
+  }
+}
+
+@each $key, $value in $ads-mobile-alignments {
+  .align-self-mb-#{$key} {
+    align-self: $value;
+  }
+}

--- a/src/layouts/GridMobile/breakpoints-gridmobile.scss
+++ b/src/layouts/GridMobile/breakpoints-gridmobile.scss
@@ -1,0 +1,13 @@
+$ads-mobile-breakpoints: (
+  small: 320px,
+  medium: 375px,
+  large: 430px
+);
+
+$ads-mobile-alignments: (
+  start: flex-start,
+  center: center,
+  end: flex-end,
+  stretch: stretch
+);
+

--- a/src/stories/GridMobile.stories.tsx
+++ b/src/stories/GridMobile.stories.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import '../layouts/GridMobile/GridMobile.scss'; 
+
+export default {
+  title: 'Layout/GridMobile',
+};
+
+export const GridMobileExample = () => (
+  <div className="container-mobile">
+    <div className="grid-mobile">
+      <div className="grid-item-mobile col-mb-2" style={{ background: 'rgb(174, 224, 201)' }}>
+        Item 1
+      </div>
+      <div className="grid-item-mobile col-mb-2" style={{ background: 'rgb(174, 224, 201)' }}>
+        Item 2
+      </div>
+      <div className="grid-item-mobile col-mb-4" style={{ background: 'rgb(174, 224, 201)' }}>
+        Item 3
+      </div>
+    </div>
+  </div>
+);


### PR DESCRIPTION
IISSUE 4: Implement Grid for Mobile (430px - Fluid) #228
![Figma_gridMobile](https://github.com/user-attachments/assets/a6e86007-b3a3-4d65-a4d9-a5d662299f3f)
A grid system was implemented for mobile devices with a 398px wide container, 16px side margins, and a 4-column layout with 16px gutter spacing, including for iPhone 14 and iPhone 15 Pro Max devices.
