### PR TITLE
feat: implement OlUlList component with styles, stories, and tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "astro-sitemap": "1.0.0",
     "astrojs-service-worker": "2.0.0",
     "classnames": "2.5.1",
+    "clsx": "^2.1.1",
     "eslint-config-standard": "17.1.0",
     "express": "^4.19.2",
     "glider-js": "^1.7.9",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "astro-sitemap": "1.0.0",
     "astrojs-service-worker": "2.0.0",
     "classnames": "2.5.1",
-    "clsx": "^2.1.1",
     "eslint-config-standard": "17.1.0",
     "express": "^4.19.2",
     "glider-js": "^1.7.9",

--- a/src/library/component/molecules/ol-ul-list/OlUlList.module.scss
+++ b/src/library/component/molecules/ol-ul-list/OlUlList.module.scss
@@ -4,7 +4,7 @@
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
-  width: 32.938rem;
+  width: 100%;
 }
 
 .ol-ul-list__item {

--- a/src/library/component/molecules/ol-ul-list/OlUlList.module.scss
+++ b/src/library/component/molecules/ol-ul-list/OlUlList.module.scss
@@ -1,0 +1,79 @@
+@import '../../../../globals/variables';
+
+.ol-ul-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  width: 32.938rem;
+}
+
+.ol-ul-list__item {
+  align-items: flex-start;
+  display: flex;
+  gap: 1.5rem;
+
+  .ol-ul-list__item-content {
+    flex: 1;
+
+    h3 {
+      color: $ads-icontextstat-color-title;
+      font-size: 0.95em;
+      font-weight: 600;
+      margin: 0 0 4px;
+    }
+
+    p {
+      color: $ads-icontextstat-color-text;
+      line-height: 1.5;
+      margin: 0;
+    }
+  }
+}
+
+.extra-small {
+  .ol-ul-list__item-content {
+    h3 {
+      font-size: 1rem;
+    }
+
+    p {
+      font-size: 0.875rem;
+    }
+  }
+}
+
+.small {
+  .ol-ul-list__item-content {
+    h3 {
+      font-size: 1.125rem;
+    }
+
+    p {
+      font-size: 1rem;
+    }
+  }
+}
+
+.medium {
+  .ol-ul-list__item-content {
+    h3 {
+      font-size: 1.25rem;
+    }
+
+    p {
+      font-size: 1.125rem;
+    }
+  }
+}
+
+.large {
+  .ol-ul-list__item-content {
+    h3 {
+      font-size: 1.5rem;
+    }
+
+    p {
+      font-size: 1.25rem;
+    }
+  }
+}

--- a/src/library/component/molecules/ol-ul-list/OlUlList.stories.tsx
+++ b/src/library/component/molecules/ol-ul-list/OlUlList.stories.tsx
@@ -1,0 +1,109 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import OlUlList from './OlUlList';
+
+const meta = {
+  title: 'library/component/molecules/ol-ul-list',
+  component: OlUlList,
+  argTypes: {
+    type: {
+      control: {
+        type: 'select',
+        options: ['ordered', 'unordered'],
+      },
+    },
+    style: {
+      control: {
+        type: 'select',
+        options: ['circle', 'square', 'rounded'],
+      },
+    },
+    size: {
+      control: {
+        type: 'select',
+        options: ['extra-small', 'small', 'medium', 'large'],
+      },
+    },
+    count: {
+      control: {
+        type: 'number',
+        min: 1,
+        max: 20,
+      },
+    },
+    items: {
+      control: {
+        type: 'object',
+      },
+    },
+  },
+} as Meta<typeof OlUlList>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ExtraSmallList: Story = {
+  args: {
+    type: 'unordered',
+    style: 'circle',
+    size: 'extra-small',
+    count: 3,
+  },
+};
+
+export const SmallList: Story = {
+  args: {
+    type: 'unordered',
+    style: 'circle',
+    size: 'small',
+    count: 3,
+  },
+};
+
+export const MediumList: Story = {
+  args: {
+    type: 'unordered',
+    style: 'circle',
+    size: 'medium',
+    count: 3,
+  },
+};
+
+export const LargeList: Story = {
+  args: {
+    type: 'unordered',
+    style: 'circle',
+    size: 'large',
+    count: 3,
+  },
+};
+
+export const WithCustomItems: Story = {
+  args: {
+    type: 'ordered',
+    style: 'rounded',
+    size: 'medium',
+    items: [
+      {
+        id: 1,
+        subtitle: 'Harmonizing Human Experience: The Artistry of UI-UX Design',
+        paragraph:
+          'UI is the canvas, UX the brushstroke; together, they craft an immersive journey where every pixel tells a story of ' +
+          'elegance, efficiency, and effortless delight. Its the artistry of design at its finest.',
+      },
+      {
+        id: 2,
+        subtitle: 'Harmonizing Human Experience: The Artistry of UI-UX Design',
+        paragraph:
+          'UI is the canvas, UX the brushstroke; together, they craft an immersive journey where every pixel tells a story of ' +
+          'elegance, efficiency, and effortless delight. Its the artistry of design at its finest.',
+      },
+      {
+        id: 3,
+        subtitle: 'Harmonizing Human Experience: The Artistry of UI-UX Design',
+        paragraph:
+          'UI is the canvas, UX the brushstroke; together, they craft an immersive journey where every pixel tells a story of ' +
+          'elegance, efficiency, and effortless delight. Its the artistry of design at its finest.',
+      },
+    ],
+  },
+};

--- a/src/library/component/molecules/ol-ul-list/OlUlList.test.jsx
+++ b/src/library/component/molecules/ol-ul-list/OlUlList.test.jsx
@@ -1,0 +1,78 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { vi } from 'vitest';
+
+import OlUlList from './OlUlList.tsx';
+
+vi.mock('../../../../ui/components/atoms/ol-item/OLItem', () => ({
+  default: ({ value, ...otherProps }) => (
+    <div data-testid="ol-item" data-value={value} data-props={JSON.stringify(otherProps)}>
+      OLItem {value}
+    </div>
+  ),
+}));
+
+vi.mock('../../../../ui/components/atoms/ol-bullet/OLBullet', () => ({
+  default: (props) => (
+    <div data-testid="ol-bullet" data-props={JSON.stringify(props)}>
+      OLBullet
+    </div>
+  ),
+}));
+
+describe('OlUlList', () => {
+  it('renders the correct number of items when count is used and items is empty', () => {
+    render(<OlUlList type="unordered" count={3} />);
+    const items = screen.getAllByText(/Este es el párrafo del elemento/i);
+    expect(items).toHaveLength(3);
+  });
+
+  it('renders custom items when items are provided', () => {
+    const items = [
+      { subtitle: 'Título 1', paragraph: 'Texto 1' },
+      { subtitle: 'Título 2', paragraph: 'Texto 2' },
+    ];
+    render(<OlUlList type="unordered" items={items} />);
+    expect(screen.getByText('Título 1')).toBeInTheDocument();
+    expect(screen.getByText('Texto 2')).toBeInTheDocument();
+  });
+
+  it('renders OLItem for ordered lists', () => {
+    render(<OlUlList type="ordered" count={2} />);
+    expect(screen.getAllByTestId('ol-item')).toHaveLength(2);
+  });
+
+  it('renders OLBullet for unordered lists', () => {
+    render(<OlUlList type="unordered" count={2} />);
+    expect(screen.getAllByTestId('ol-bullet')).toHaveLength(2);
+  });
+
+  it('applies the correct size class based on props', () => {
+    const { container } = render(<OlUlList type="unordered" size="large" count={1} />);
+    expect(container.firstChild?.className).toMatch(/large/);
+  });
+
+  it('falls back to medium size if unknown size is provided', () => {
+    const { container } = render(<OlUlList type="unordered" size="invalid" count={1} />);
+
+    const element = container.firstChild;
+    const classNames = element?.className || '';
+    expect(classNames).toMatch(/medium/);
+    expect(classNames).not.toMatch(/invalid/);
+    expect(classNames).toMatch(/ol-ul-list/);
+    expect(classNames).toMatch(/unordered/);
+  });
+
+  it('applies the correct classes for type and style', () => {
+    const { container } = render(<OlUlList type="ordered" count={1} />);
+    expect(container.firstChild?.className).toMatch(/ordered/);
+  });
+
+  it('renders default content if subtitle or paragraph is missing', () => {
+    const items = [{ subtitle: undefined, paragraph: undefined }];
+    render(<OlUlList type="unordered" items={items} />);
+    expect(screen.queryByRole('heading')).not.toBeInTheDocument();
+    expect(screen.queryByText(/Este es el párrafo/i)).not.toBeInTheDocument();
+  });
+});

--- a/src/library/component/molecules/ol-ul-list/OlUlList.tsx
+++ b/src/library/component/molecules/ol-ul-list/OlUlList.tsx
@@ -4,6 +4,19 @@ import OLBullet from '../../../../ui/components/atoms/ol-bullet/OLBullet';
 import styles from './OlUlList.module.scss';
 import type { IProps } from './types/IProps';
 
+const getSizeClasses = (size: string) => ({
+  [styles['extra-small']]: size === 'extra-small',
+  [styles.small]: size === 'small',
+  [styles.medium]: size === 'medium' || !['extra-small', 'small', 'large'].includes(size),
+  [styles.large]: size === 'large',
+});
+
+const getOLItemSize = (size: string): 'sm' | 'md' | 'lg' => {
+  if (size === 'extra-small' || size === 'small') return 'sm';
+  if (size === 'large') return 'lg';
+  return 'md';
+};
+
 function OlUlList({ type, style = 'circle', size = 'medium', items = [], count = 1 }: IProps) {
   const containerClasses = clsx(
     styles['ol-ul-list'],
@@ -12,28 +25,12 @@ function OlUlList({ type, style = 'circle', size = 'medium', items = [], count =
       [styles.unordered]: type === 'unordered',
     },
     styles[`${style}List`] || styles.circleList,
-    {
-      [styles['extra-small']]: size === 'extra-small',
-      [styles.small]: size === 'small',
-      [styles.medium]: size === 'medium' || !['extra-small', 'small', 'large'].includes(size),
-      [styles.large]: size === 'large',
-    },
+    getSizeClasses(size),
   );
 
-  const contentSizeClass = clsx({
-    [styles['extra-small']]: size === 'extra-small',
-    [styles.small]: size === 'small',
-    [styles.medium]: size === 'medium' || !['extra-small', 'small', 'large'].includes(size),
-    [styles.large]: size === 'large',
-  });
+  const contentSizeClass = clsx(getSizeClasses(size));
 
-  const olItemSize = clsx({
-    sm: size === 'extra-small' || size === 'small',
-    md: size === 'medium' || !['extra-small', 'small', 'large'].includes(size),
-    lg: size === 'large',
-  }) as 'sm' | 'md' | 'lg';
-
-  const olItemStyle = style;
+  const olItemSize = getOLItemSize(size);
 
   const renderListItems = () => {
     const listData =
@@ -44,19 +41,23 @@ function OlUlList({ type, style = 'circle', size = 'medium', items = [], count =
             paragraph: `Este es el párrafo del elemento ${String(i + 1)} de la lista.`,
           }));
 
-    return listData.map((item, index) => (
-      <div key={item.subtitle ?? index} className={styles['ol-ul-list__item']}>
-        {type === 'ordered' ? (
-          <OLItem value={String(index + 1)} active shape={olItemStyle} size={olItemSize} />
-        ) : (
-          <OLBullet active shape={olItemStyle} size={olItemSize} />
-        )}
-        <div className={styles['ol-ul-list__item-content']}>
-          {item.subtitle && <h3 className={contentSizeClass}>{item.subtitle}</h3>}
-          {item.paragraph && <p className={contentSizeClass}>{item.paragraph}</p>}
+    return listData.map((item, index) => {
+      const safeKey = `${item.subtitle ?? 'item'}-${String(index)}`;
+
+      return (
+        <div key={safeKey} className={styles['ol-ul-list__item']}>
+          {type === 'ordered' ? (
+            <OLItem value={String(index + 1)} active shape={style} size={olItemSize} />
+          ) : (
+            <OLBullet active shape={style} size={olItemSize} />
+          )}
+          <div className={styles['ol-ul-list__item-content']}>
+            {item.subtitle && <h3 className={contentSizeClass}>{item.subtitle}</h3>}
+            {item.paragraph && <p className={contentSizeClass}>{item.paragraph}</p>}
+          </div>
         </div>
-      </div>
-    ));
+      );
+    });
   };
 
   return <div className={containerClasses}>{renderListItems()}</div>;

--- a/src/library/component/molecules/ol-ul-list/OlUlList.tsx
+++ b/src/library/component/molecules/ol-ul-list/OlUlList.tsx
@@ -1,4 +1,4 @@
-import clsx from 'clsx';
+import classnames from 'classnames';
 import OLItem from '../../../../ui/components/atoms/ol-item/OLItem';
 import OLBullet from '../../../../ui/components/atoms/ol-bullet/OLBullet';
 import styles from './OlUlList.module.scss';
@@ -18,7 +18,7 @@ const getOLItemSize = (size: string): 'sm' | 'md' | 'lg' => {
 };
 
 function OlUlList({ type, style = 'circle', size = 'medium', items = [], count = 1 }: IProps) {
-  const containerClasses = clsx(
+  const containerClasses = classnames(
     styles['ol-ul-list'],
     {
       [styles.ordered]: type === 'ordered',
@@ -28,7 +28,7 @@ function OlUlList({ type, style = 'circle', size = 'medium', items = [], count =
     getSizeClasses(size),
   );
 
-  const contentSizeClass = clsx(getSizeClasses(size));
+  const contentSizeClass = classnames(getSizeClasses(size));
 
   const olItemSize = getOLItemSize(size);
 

--- a/src/library/component/molecules/ol-ul-list/OlUlList.tsx
+++ b/src/library/component/molecules/ol-ul-list/OlUlList.tsx
@@ -1,0 +1,53 @@
+import OLItem from '../../../../ui/components/atoms/ol-item/OLItem';
+import OLBullet from '../../../../ui/components/atoms/ol-bullet/OLBullet';
+import styles from './OlUlList.module.scss';
+import type { IProps } from './types/IProps';
+
+function OlUlList({ type, style = 'circle', size = 'medium', items = [], count = 1 }: IProps) {
+  const listType = type === 'ordered' ? styles.ordered : styles.unordered;
+  const listStyle = styles[`${style}List`] ?? styles.circleList;
+  const olItemStyle = style;
+  const validSizes = ['extra-small', 'small', 'medium', 'large'];
+  const validSize = validSizes.includes(size) ? size : 'medium';
+  const sizeList = styles[validSize];
+
+  const sizeMap: Record<NonNullable<IProps['size']>, 'sm' | 'md' | 'lg'> = {
+    'extra-small': 'sm',
+    small: 'sm',
+    medium: 'md',
+    large: 'lg',
+  };
+  const olItemSize = sizeMap[validSize];
+
+  const renderListItems = () => {
+    const listData =
+      items.length > 0
+        ? items
+        : Array.from({ length: count }, (_, i) => ({
+            subtitle: `Subtítulo ${String(i + 1)}`,
+            paragraph: `Este es el párrafo del elemento ${String(i + 1)} de la lista.`,
+          }));
+
+    return listData.map((item, index) => (
+      <div key={item.subtitle ?? index} className={styles['ol-ul-list__item']}>
+        {type === 'ordered' ? (
+          <OLItem value={String(index + 1)} active shape={olItemStyle} size={olItemSize} />
+        ) : (
+          <OLBullet active shape={olItemStyle} size={olItemSize} />
+        )}
+        <div className={styles['ol-ul-list__item-content']}>
+          {item.subtitle && <h3 className={sizeList}>{item.subtitle}</h3>}
+          {item.paragraph && <p className={sizeList}>{item.paragraph}</p>}
+        </div>
+      </div>
+    ));
+  };
+
+  return (
+    <div className={`${styles['ol-ul-list']} ${listType} ${listStyle} ${sizeList}`}>
+      {renderListItems()}
+    </div>
+  );
+}
+
+export default OlUlList;

--- a/src/library/component/molecules/ol-ul-list/OlUlList.tsx
+++ b/src/library/component/molecules/ol-ul-list/OlUlList.tsx
@@ -1,23 +1,39 @@
+import clsx from 'clsx';
 import OLItem from '../../../../ui/components/atoms/ol-item/OLItem';
 import OLBullet from '../../../../ui/components/atoms/ol-bullet/OLBullet';
 import styles from './OlUlList.module.scss';
 import type { IProps } from './types/IProps';
 
 function OlUlList({ type, style = 'circle', size = 'medium', items = [], count = 1 }: IProps) {
-  const listType = type === 'ordered' ? styles.ordered : styles.unordered;
-  const listStyle = styles[`${style}List`] ?? styles.circleList;
-  const olItemStyle = style;
-  const validSizes = ['extra-small', 'small', 'medium', 'large'];
-  const validSize = validSizes.includes(size) ? size : 'medium';
-  const sizeList = styles[validSize];
+  const containerClasses = clsx(
+    styles['ol-ul-list'],
+    {
+      [styles.ordered]: type === 'ordered',
+      [styles.unordered]: type === 'unordered',
+    },
+    styles[`${style}List`] || styles.circleList,
+    {
+      [styles['extra-small']]: size === 'extra-small',
+      [styles.small]: size === 'small',
+      [styles.medium]: size === 'medium' || !['extra-small', 'small', 'large'].includes(size),
+      [styles.large]: size === 'large',
+    },
+  );
 
-  const sizeMap: Record<NonNullable<IProps['size']>, 'sm' | 'md' | 'lg'> = {
-    'extra-small': 'sm',
-    small: 'sm',
-    medium: 'md',
-    large: 'lg',
-  };
-  const olItemSize = sizeMap[validSize];
+  const contentSizeClass = clsx({
+    [styles['extra-small']]: size === 'extra-small',
+    [styles.small]: size === 'small',
+    [styles.medium]: size === 'medium' || !['extra-small', 'small', 'large'].includes(size),
+    [styles.large]: size === 'large',
+  });
+
+  const olItemSize = clsx({
+    sm: size === 'extra-small' || size === 'small',
+    md: size === 'medium' || !['extra-small', 'small', 'large'].includes(size),
+    lg: size === 'large',
+  }) as 'sm' | 'md' | 'lg';
+
+  const olItemStyle = style;
 
   const renderListItems = () => {
     const listData =
@@ -36,18 +52,14 @@ function OlUlList({ type, style = 'circle', size = 'medium', items = [], count =
           <OLBullet active shape={olItemStyle} size={olItemSize} />
         )}
         <div className={styles['ol-ul-list__item-content']}>
-          {item.subtitle && <h3 className={sizeList}>{item.subtitle}</h3>}
-          {item.paragraph && <p className={sizeList}>{item.paragraph}</p>}
+          {item.subtitle && <h3 className={contentSizeClass}>{item.subtitle}</h3>}
+          {item.paragraph && <p className={contentSizeClass}>{item.paragraph}</p>}
         </div>
       </div>
     ));
   };
 
-  return (
-    <div className={`${styles['ol-ul-list']} ${listType} ${listStyle} ${sizeList}`}>
-      {renderListItems()}
-    </div>
-  );
+  return <div className={containerClasses}>{renderListItems()}</div>;
 }
 
 export default OlUlList;

--- a/src/library/component/molecules/ol-ul-list/types/IProps.ts
+++ b/src/library/component/molecules/ol-ul-list/types/IProps.ts
@@ -1,0 +1,17 @@
+export interface IListItem {
+  id: number;
+  subtitle?: string;
+  paragraph?: string;
+}
+
+export type ListType = 'ordered' | 'unordered';
+export type ListStyle = 'square' | 'rounded' | 'circle';
+export type ListSize = 'extra-small' | 'small' | 'medium' | 'large';
+
+export interface IProps {
+  type: ListType;
+  style?: ListStyle;
+  size?: ListSize;
+  items?: IListItem[];
+  count?: number;
+}


### PR DESCRIPTION
Description:
Implement OlUlList component with styles, stories, and tests
Sumary:
- Implemented OlUlList component with props for type (ordered/unordered), style (circle, square, rounded), size (extra-small, small, medium, large), and count to control list generation dynamically.
- Created corresponding SCSS module to support customizable list styles and spacing, reflecting the style and size props visually.
- Added Storybook stories for visual testing and documentation, with interactive controls (argTypes) for all props to preview different list configurations.
- Validated component behavior to ensure proper rendering of list type and item count based on props.
#334 
![image](https://github.com/user-attachments/assets/ff1461e8-c99a-45e2-bc38-ccc89995880e)
![image](https://github.com/user-attachments/assets/7c1dc3b5-89ec-4fa2-a69a-eea7d1dff981)