### PR TITLE
Refactor_CountryListDropdown

### DIFF
--- a/src/ui/components/atoms/CountryFlag/CountryFlag.tsx
+++ b/src/ui/components/atoms/CountryFlag/CountryFlag.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import Avatar from '@mui/material/Avatar';
+
+interface CountryFlagProps {
+  src: string;
+  alt: string;
+  size?: number;
+}
+
+export function CountryFlag({ src, alt, size = 24 }: CountryFlagProps): JSX.Element {
+  return <Avatar src={src} alt={alt} sx={{ width: size, height: size, marginRight: 1.5 }} />;
+}

--- a/src/ui/components/atoms/CountryText/CountryText.tsx
+++ b/src/ui/components/atoms/CountryText/CountryText.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import Typography from '@mui/material/Typography';
+
+interface CountryTextProps {
+  text: string;
+  variant: 'name' | 'dialCode';
+}
+
+export function CountryText({ text, variant }: CountryTextProps): JSX.Element {
+  if (variant === 'name') {
+    return (
+      <Typography component="span" variant="body1" sx={{ flexGrow: 1, fontWeight: 'medium' }}>
+        {text}
+      </Typography>
+    );
+  }
+  return (
+    <Typography component="span" variant="body2" color="text.secondary">
+      ({text})
+    </Typography>
+  );
+}

--- a/src/ui/components/atoms/DropdownButton/DropdownButton.tsx
+++ b/src/ui/components/atoms/DropdownButton/DropdownButton.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import Button from '@mui/material/Button';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import Box from '@mui/material/Box';
+import { CountryFlag } from '../CountryFlag/CountryFlag';
+import type { Country } from '../../organisms/CountryListDropdown/types/IProps';
+
+interface DropdownButtonProps {
+  selectedCountry?: Country;
+  onClick: () => void;
+  isOpen: boolean;
+  headerText?: string;
+  width?: string | number;
+}
+
+export function DropdownButton({
+  selectedCountry,
+  onClick,
+  isOpen,
+  headerText = 'Select Country',
+  width = '100%',
+}: DropdownButtonProps): JSX.Element {
+  return (
+    <Button
+      variant="outlined"
+      onClick={onClick}
+      fullWidth
+      endIcon={
+        <KeyboardArrowDownIcon
+          sx={{
+            transform: isOpen ? 'rotate(180deg)' : 'rotate(0deg)',
+            transition: 'transform 0.2s',
+          }}
+        />
+      }
+      sx={{
+        justifyContent: 'space-between',
+        textAlign: 'left',
+        padding: '14px',
+        borderColor: 'divider',
+        color: 'text.primary',
+        backgroundColor: 'background.paper',
+        width,
+        '&:hover': {
+          borderColor: 'primary.main',
+          backgroundColor: 'action.hover',
+        },
+        borderRadius: '8px',
+        textTransform: 'none',
+        fontSize: '16px',
+        fontWeight: 'bold',
+      }}
+    >
+      {selectedCountry ? (
+        <Box sx={{ display: 'flex', alignItems: 'center' }}>
+          <CountryFlag src={selectedCountry.flag} alt={selectedCountry.name} size={20} />
+          {selectedCountry.name}
+        </Box>
+      ) : (
+        headerText
+      )}
+    </Button>
+  );
+}

--- a/src/ui/components/molecules/CountrySelectList/CountrySelectList.tsx
+++ b/src/ui/components/molecules/CountrySelectList/CountrySelectList.tsx
@@ -1,0 +1,93 @@
+import React, { forwardRef } from 'react';
+import List from '@mui/material/List';
+import ListItemButton from '@mui/material/ListItemButton';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Paper from '@mui/material/Paper';
+import ListItemText from '@mui/material/ListItemText';
+import { CountryFlag } from '../../atoms/CountryFlag/CountryFlag';
+import type { Country } from '../../organisms/CountryListDropdown/types/IProps';
+
+interface CountrySelectListProps {
+  countries: Country[];
+  onSelectCountry: (countryCode: string) => void;
+  selectedCountryCode?: string;
+  highlightIndex: number;
+  headerText?: string;
+  maxHeight?: string | number;
+}
+
+export const CountrySelectList = forwardRef<HTMLDivElement, CountrySelectListProps>(
+  (
+    {
+      countries,
+      onSelectCountry,
+      selectedCountryCode,
+      highlightIndex,
+      headerText,
+      maxHeight = 314,
+    },
+    ref,
+  ) => {
+    return (
+      <Paper
+        elevation={3}
+        sx={{
+          zIndex: 1300,
+          width: '100%',
+          borderRadius: '12px',
+          backgroundColor: 'background.paper',
+          boxShadow: '0px 4px 12px rgba(0, 0, 0, 0.1)',
+          overflow: 'hidden',
+        }}
+      >
+        {headerText && (
+          <Typography variant="h6" sx={{ p: 2, fontWeight: 'bold' }}>
+            {headerText}
+          </Typography>
+        )}
+        <Box
+          ref={ref}
+          sx={{
+            maxHeight,
+            overflowY: 'auto',
+            '&::-webkit-scrollbar': { width: '8px' },
+            '&::-webkit-scrollbar-track': { background: '#f1f1f1' },
+            '&::-webkit-scrollbar-thumb': { background: '#8A3FFC', borderRadius: '4px' },
+            '&::-webkit-scrollbar-thumb:hover': { background: '#772ce8' },
+          }}
+        >
+          <List dense disablePadding role="presentation">
+            {countries.map((country: Country, index: number) => (
+              <ListItemButton
+                key={country.code}
+                selected={selectedCountryCode === country.code}
+                onClick={() => {
+                  onSelectCountry(country.code);
+                }}
+                sx={{
+                  padding: '12px 16px',
+                  '&.Mui-selected': {
+                    backgroundColor: 'action.focus',
+                    '&:hover': {
+                      backgroundColor: 'action.focus',
+                    },
+                  },
+                  ...(highlightIndex === index && { backgroundColor: 'action.hover' }),
+                }}
+                role="option"
+                aria-selected={selectedCountryCode === country.code}
+                id={`country-item-${country.code}`}
+              >
+                <CountryFlag src={country.flag} alt={country.name} />
+                <ListItemText primary={`${country.name} (${country.dialCode})`} sx={{ ml: 2 }} />
+              </ListItemButton>
+            ))}
+          </List>
+        </Box>
+      </Paper>
+    );
+  },
+);
+
+CountrySelectList.displayName = 'CountrySelectList';

--- a/src/ui/components/molecules/CountrySelectList/CountrySelectList.tsx
+++ b/src/ui/components/molecules/CountrySelectList/CountrySelectList.tsx
@@ -32,14 +32,13 @@ export const CountrySelectList = forwardRef<HTMLDivElement, CountrySelectListPro
     return (
       <Paper
         elevation={3}
-        sx={{
+        sx={(theme) => ({
           zIndex: 1300,
           width: '100%',
-          borderRadius: '12px',
+          borderRadius: theme.spacing(1.5),
           backgroundColor: 'background.paper',
-          boxShadow: '0px 4px 12px rgba(0, 0, 0, 0.1)',
           overflow: 'hidden',
-        }}
+        })}
       >
         {headerText && (
           <Typography variant="h6" sx={{ p: 2, fontWeight: 'bold' }}>

--- a/src/ui/components/organisms/CountryListDropdown/CountryListDropdown.stories.tsx
+++ b/src/ui/components/organisms/CountryListDropdown/CountryListDropdown.stories.tsx
@@ -2,36 +2,17 @@ import React, { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import Box from '@mui/material/Box';
 import { CountryListDropdown } from './CountryListDropdown';
-import type { CountryListDropdownProps, Country } from './types/IProps';
-
-const countriesForStory: Country[] = [
-  { code: 'AF', name: 'Afganistán', flag: 'https://flagcdn.com/w320/af.png', dialCode: '+93' },
-  { code: 'AL', name: 'Albania', flag: 'https://flagcdn.com/w320/al.png', dialCode: '+355' },
-  { code: 'DE', name: 'Alemania', flag: 'https://flagcdn.com/w320/de.png', dialCode: '+49' },
-  { code: 'AD', name: 'Andorra', flag: 'https://flagcdn.com/w320/ad.png', dialCode: '+376' },
-  { code: 'AO', name: 'Angola', flag: 'https://flagcdn.com/w320/ao.png', dialCode: '+244' },
-  { code: 'DZ', name: 'Argelia', flag: 'https://flagcdn.com/w320/dz.png', dialCode: '+213' },
-  { code: 'AR', name: 'Argentina', flag: 'https://flagcdn.com/w320/ar.png', dialCode: '+54' },
-  { code: 'AM', name: 'Armenia', flag: 'https://flagcdn.com/w320/am.png', dialCode: '+374' },
-  { code: 'AU', name: 'Australia', flag: 'https://flagcdn.com/w320/au.png', dialCode: '+61' },
-  { code: 'AT', name: 'Austria', flag: 'https://flagcdn.com/w320/at.png', dialCode: '+43' },
-  { code: 'AZ', name: 'Azerbaiyán', flag: 'https://flagcdn.com/w320/az.png', dialCode: '+994' },
-  { code: 'BR', name: 'Brasil', flag: 'https://flagcdn.com/w320/br.png', dialCode: '+55' },
-  { code: 'CA', name: 'Canadá', flag: 'https://flagcdn.com/w320/ca.png', dialCode: '+1' },
-  { code: 'CN', name: 'China', flag: 'https://flagcdn.com/w320/cn.png', dialCode: '+86' },
-  { code: 'ES', name: 'España', flag: 'https://flagcdn.com/w320/es.png', dialCode: '+34' },
-  { code: 'US', name: 'Estados Unidos', flag: 'https://flagcdn.com/w320/us.png', dialCode: '+1' },
-  { code: 'FR', name: 'Francia', flag: 'https://flagcdn.com/w320/fr.png', dialCode: '+33' },
-  { code: 'IT', name: 'Italia', flag: 'https://flagcdn.com/w320/it.png', dialCode: '+39' },
-  { code: 'MX', name: 'México', flag: 'https://flagcdn.com/w320/mx.png', dialCode: '+52' },
-  { code: 'GB', name: 'Reino Unido', flag: 'https://flagcdn.com/w320/gb.png', dialCode: '+44' },
-];
+import type { CountryListDropdownProps } from './types/IProps';
+import { MockCountriesData } from './MockCountries';
 
 const meta: Meta<typeof CountryListDropdown> = {
   title: 'ui/components/organisms/CountryListDropdown',
   component: CountryListDropdown,
   argTypes: {
-    selectedCountry: { control: 'select', options: ['', ...countriesForStory.map((c) => c.code)] },
+    selectedCountry: {
+      control: 'select',
+      options: ['', ...MockCountriesData.map((c) => c.code)],
+    },
     onSelectCountry: { action: 'selectedCountry' },
     maxHeight: { control: 'text' },
     width: { control: 'text' },
@@ -88,7 +69,7 @@ export const Default: Story = {
     headerText: 'Select Country',
     width: '320px',
     maxHeight: '350px',
-    countries: countriesForStory,
+    countries: MockCountriesData,
     selectedCountry: 'AR',
   },
 };

--- a/src/ui/components/organisms/CountryListDropdown/CountryListDropdown.stories.tsx
+++ b/src/ui/components/organisms/CountryListDropdown/CountryListDropdown.stories.tsx
@@ -1,0 +1,94 @@
+import React, { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import Box from '@mui/material/Box';
+import { CountryListDropdown } from './CountryListDropdown';
+import type { CountryListDropdownProps, Country } from './types/IProps';
+
+const countriesForStory: Country[] = [
+  { code: 'AF', name: 'Afganistán', flag: 'https://flagcdn.com/w320/af.png', dialCode: '+93' },
+  { code: 'AL', name: 'Albania', flag: 'https://flagcdn.com/w320/al.png', dialCode: '+355' },
+  { code: 'DE', name: 'Alemania', flag: 'https://flagcdn.com/w320/de.png', dialCode: '+49' },
+  { code: 'AD', name: 'Andorra', flag: 'https://flagcdn.com/w320/ad.png', dialCode: '+376' },
+  { code: 'AO', name: 'Angola', flag: 'https://flagcdn.com/w320/ao.png', dialCode: '+244' },
+  { code: 'DZ', name: 'Argelia', flag: 'https://flagcdn.com/w320/dz.png', dialCode: '+213' },
+  { code: 'AR', name: 'Argentina', flag: 'https://flagcdn.com/w320/ar.png', dialCode: '+54' },
+  { code: 'AM', name: 'Armenia', flag: 'https://flagcdn.com/w320/am.png', dialCode: '+374' },
+  { code: 'AU', name: 'Australia', flag: 'https://flagcdn.com/w320/au.png', dialCode: '+61' },
+  { code: 'AT', name: 'Austria', flag: 'https://flagcdn.com/w320/at.png', dialCode: '+43' },
+  { code: 'AZ', name: 'Azerbaiyán', flag: 'https://flagcdn.com/w320/az.png', dialCode: '+994' },
+  { code: 'BR', name: 'Brasil', flag: 'https://flagcdn.com/w320/br.png', dialCode: '+55' },
+  { code: 'CA', name: 'Canadá', flag: 'https://flagcdn.com/w320/ca.png', dialCode: '+1' },
+  { code: 'CN', name: 'China', flag: 'https://flagcdn.com/w320/cn.png', dialCode: '+86' },
+  { code: 'ES', name: 'España', flag: 'https://flagcdn.com/w320/es.png', dialCode: '+34' },
+  { code: 'US', name: 'Estados Unidos', flag: 'https://flagcdn.com/w320/us.png', dialCode: '+1' },
+  { code: 'FR', name: 'Francia', flag: 'https://flagcdn.com/w320/fr.png', dialCode: '+33' },
+  { code: 'IT', name: 'Italia', flag: 'https://flagcdn.com/w320/it.png', dialCode: '+39' },
+  { code: 'MX', name: 'México', flag: 'https://flagcdn.com/w320/mx.png', dialCode: '+52' },
+  { code: 'GB', name: 'Reino Unido', flag: 'https://flagcdn.com/w320/gb.png', dialCode: '+44' },
+];
+
+const meta: Meta<typeof CountryListDropdown> = {
+  title: 'ui/components/organisms/CountryListDropdown',
+  component: CountryListDropdown,
+  argTypes: {
+    selectedCountry: { control: 'select', options: ['', ...countriesForStory.map((c) => c.code)] },
+    onSelectCountry: { action: 'selectedCountry' },
+    maxHeight: { control: 'text' },
+    width: { control: 'text' },
+    headerText: { control: 'text' },
+    countries: { control: false },
+  },
+  parameters: {
+    layout: 'padded',
+  },
+  decorators: [
+    (Story) => (
+      <Box sx={{ width: 'auto', maxWidth: 400, padding: '20px' }}>
+        <Story />
+      </Box>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<CountryListDropdownProps>;
+
+function InteractiveStoryWrapper(props: CountryListDropdownProps): JSX.Element {
+  const {
+    selectedCountry: initialSelectedCountry,
+    onSelectCountry,
+    countries,
+    headerText,
+    width,
+    maxHeight,
+  } = props;
+  const [selected, setSelected] = useState(initialSelectedCountry);
+
+  const handleSelectCountry = (code: string): void => {
+    setSelected(code);
+    onSelectCountry(code);
+  };
+
+  return (
+    <CountryListDropdown
+      countries={countries}
+      headerText={headerText}
+      width={width}
+      maxHeight={maxHeight}
+      selectedCountry={selected}
+      onSelectCountry={handleSelectCountry}
+    />
+  );
+}
+
+export const Default: Story = {
+  render: InteractiveStoryWrapper,
+  args: {
+    headerText: 'Select Country',
+    width: '320px',
+    maxHeight: '350px',
+    countries: countriesForStory,
+    selectedCountry: 'AR',
+  },
+};

--- a/src/ui/components/organisms/CountryListDropdown/CountryListDropdown.test.tsx
+++ b/src/ui/components/organisms/CountryListDropdown/CountryListDropdown.test.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { vi } from 'vitest';
+import { CountryListDropdown } from './CountryListDropdown';
+import type { CountryListDropdownProps, Country } from './types/IProps';
+
+const testCountries: Country[] = [
+  { code: 'AR', name: 'Argentina', flag: 'https://flagcdn.com/w320/ar.png', dialCode: '+54' },
+  { code: 'AF', name: 'Afganistán', flag: 'https://flagcdn.com/w320/af.png', dialCode: '+93' },
+  { code: 'AL', name: 'Albania', flag: 'https://flagcdn.com/w320/al.png', dialCode: '+355' },
+];
+
+if (typeof Element.prototype.scrollIntoView !== 'function') {
+  Element.prototype.scrollIntoView = vi.fn();
+}
+
+describe('CountryListDropdown Component', () => {
+  const headerText = 'Seleccionar País';
+  const mockOnSelect = vi.fn();
+
+  beforeEach(() => {
+    mockOnSelect.mockClear();
+  });
+
+  const renderComponent = (props: Partial<CountryListDropdownProps> = {}) => {
+    const defaultProps: CountryListDropdownProps = {
+      countries: testCountries,
+      onSelectCountry: mockOnSelect,
+      headerText,
+      ...props,
+    };
+    return render(
+      <CountryListDropdown
+        countries={defaultProps.countries}
+        onSelectCountry={defaultProps.onSelectCountry}
+        headerText={defaultProps.headerText}
+        selectedCountry={defaultProps.selectedCountry}
+        maxHeight={defaultProps.maxHeight}
+        width={defaultProps.width}
+      />,
+    );
+  };
+
+  it('renders the header text correctly', () => {
+    renderComponent();
+    expect(screen.getByRole('heading', { name: headerText })).toBeInTheDocument();
+  });
+
+  it('renders a list of countries', () => {
+    renderComponent();
+    const listItems = screen.getAllByRole('option');
+    expect(listItems).toHaveLength(testCountries.length);
+    expect(screen.getByText(/Argentina/)).toBeInTheDocument();
+  });
+
+  it('highlights the selected country', () => {
+    const selectedCountryCode = testCountries[1].code;
+    renderComponent({ selectedCountry: selectedCountryCode });
+    const selectedItem = screen.getByRole('option', { name: /Afganistán/i });
+    expect(selectedItem).toHaveClass('Mui-selected');
+  });
+
+  it('calls onSelectCountry with the correct country code when an item is clicked', () => {
+    renderComponent();
+    const countryToSelect = testCountries[2];
+    const countryItem = screen.getByRole('option', { name: new RegExp(countryToSelect.name, 'i') });
+    fireEvent.click(countryItem);
+    expect(mockOnSelect).toHaveBeenCalledWith(countryToSelect.code);
+  });
+
+  it('navigates with keyboard and selects with Enter', () => {
+    renderComponent();
+    const list = screen.getByRole('listbox');
+    list.focus();
+    fireEvent.keyDown(document, { key: 'ArrowDown' });
+    fireEvent.keyDown(document, { key: 'ArrowDown' });
+    fireEvent.keyDown(document, { key: 'Enter' });
+
+    expect(mockOnSelect).toHaveBeenCalledWith(testCountries[1].code);
+  });
+});

--- a/src/ui/components/organisms/CountryListDropdown/CountryListDropdown.tsx
+++ b/src/ui/components/organisms/CountryListDropdown/CountryListDropdown.tsx
@@ -1,0 +1,93 @@
+import React, { useState, useEffect, useRef } from 'react';
+import Box from '@mui/material/Box';
+import type { Country, CountryListDropdownProps } from './types/IProps';
+import { CountrySelectList } from '../../molecules/CountrySelectList/CountrySelectList';
+
+export function CountryListDropdown({
+  countries = [],
+  selectedCountry: selectedCountryCode,
+  onSelectCountry,
+  maxHeight = 314,
+  width = 366,
+  headerText = 'Select Country',
+}: CountryListDropdownProps): JSX.Element {
+  const [highlightIndex, setHighlightIndex] = useState(-1);
+  const listContainerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const currentIndex = selectedCountryCode
+      ? countries.findIndex((c: Country) => c.code === selectedCountryCode)
+      : -1;
+    setHighlightIndex(currentIndex);
+    if (listContainerRef.current && currentIndex !== -1) {
+      const itemElement = listContainerRef.current.querySelector(
+        `#country-item-${countries[currentIndex].code}`,
+      );
+      itemElement?.scrollIntoView({ block: 'nearest' });
+    }
+  }, [countries, selectedCountryCode]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if (countries.length === 0) return;
+      let newIndex = highlightIndex;
+      switch (event.key) {
+        case 'ArrowDown':
+          event.preventDefault();
+          newIndex = highlightIndex >= countries.length - 1 ? 0 : highlightIndex + 1;
+          break;
+        case 'ArrowUp':
+          event.preventDefault();
+          newIndex = highlightIndex <= 0 ? countries.length - 1 : highlightIndex - 1;
+          break;
+        case 'Enter':
+          if (newIndex !== -1 && countries[newIndex]) {
+            event.preventDefault();
+            onSelectCountry(countries[newIndex].code);
+          }
+          return;
+        case 'Home':
+          event.preventDefault();
+          newIndex = 0;
+          break;
+        case 'End':
+          event.preventDefault();
+          newIndex = countries.length - 1;
+          break;
+        default:
+          return;
+      }
+      setHighlightIndex(newIndex);
+      if (listContainerRef.current && newIndex !== -1) {
+        const itemElement = listContainerRef.current.querySelector(
+          `#country-item-${countries[newIndex].code}`,
+        );
+        itemElement?.scrollIntoView({ block: 'nearest' });
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [highlightIndex, countries, onSelectCountry]);
+
+  return (
+    <Box
+      sx={{ position: 'relative', width, boxSizing: 'border-box' }}
+      role="listbox"
+      aria-activedescendant={
+        highlightIndex >= 0 ? `country-item-${countries[highlightIndex].code}` : undefined
+      }
+    >
+      <CountrySelectList
+        ref={listContainerRef}
+        countries={countries}
+        onSelectCountry={onSelectCountry}
+        selectedCountryCode={selectedCountryCode}
+        highlightIndex={highlightIndex}
+        headerText={headerText}
+        maxHeight={maxHeight}
+      />
+    </Box>
+  );
+}

--- a/src/ui/components/organisms/CountryListDropdown/MockCountries.ts
+++ b/src/ui/components/organisms/CountryListDropdown/MockCountries.ts
@@ -1,0 +1,24 @@
+import type { Country } from './types/IProps';
+
+export const MockCountriesData: Country[] = [
+  { code: 'AF', name: 'Afganistán', flag: 'https://flagcdn.com/w320/af.png', dialCode: '+93' },
+  { code: 'AL', name: 'Albania', flag: 'https://flagcdn.com/w320/al.png', dialCode: '+355' },
+  { code: 'DE', name: 'Alemania', flag: 'https://flagcdn.com/w320/de.png', dialCode: '+49' },
+  { code: 'AD', name: 'Andorra', flag: 'https://flagcdn.com/w320/ad.png', dialCode: '+376' },
+  { code: 'AO', name: 'Angola', flag: 'https://flagcdn.com/w320/ao.png', dialCode: '+244' },
+  { code: 'DZ', name: 'Argelia', flag: 'https://flagcdn.com/w320/dz.png', dialCode: '+213' },
+  { code: 'AR', name: 'Argentina', flag: 'https://flagcdn.com/w320/ar.png', dialCode: '+54' },
+  { code: 'AM', name: 'Armenia', flag: 'https://flagcdn.com/w320/am.png', dialCode: '+374' },
+  { code: 'AU', name: 'Australia', flag: 'https://flagcdn.com/w320/au.png', dialCode: '+61' },
+  { code: 'AT', name: 'Austria', flag: 'https://flagcdn.com/w320/at.png', dialCode: '+43' },
+  { code: 'AZ', name: 'Azerbaiyán', flag: 'https://flagcdn.com/w320/az.png', dialCode: '+994' },
+  { code: 'BR', name: 'Brasil', flag: 'https://flagcdn.com/w320/br.png', dialCode: '+55' },
+  { code: 'CA', name: 'Canadá', flag: 'https://flagcdn.com/w320/ca.png', dialCode: '+1' },
+  { code: 'CN', name: 'China', flag: 'https://flagcdn.com/w320/cn.png', dialCode: '+86' },
+  { code: 'ES', name: 'España', flag: 'https://flagcdn.com/w320/es.png', dialCode: '+34' },
+  { code: 'US', name: 'Estados Unidos', flag: 'https://flagcdn.com/w320/us.png', dialCode: '+1' },
+  { code: 'FR', name: 'Francia', flag: 'https://flagcdn.com/w320/fr.png', dialCode: '+33' },
+  { code: 'IT', name: 'Italia', flag: 'https://flagcdn.com/w320/it.png', dialCode: '+39' },
+  { code: 'MX', name: 'México', flag: 'https://flagcdn.com/w320/mx.png', dialCode: '+52' },
+  { code: 'GB', name: 'Reino Unido', flag: 'https://flagcdn.com/w320/gb.png', dialCode: '+44' },
+];

--- a/src/ui/components/organisms/CountryListDropdown/types/IProps.ts
+++ b/src/ui/components/organisms/CountryListDropdown/types/IProps.ts
@@ -1,0 +1,15 @@
+export interface Country {
+  code: string;
+  name: string;
+  flag: string;
+  dialCode: string;
+}
+
+export interface CountryListDropdownProps {
+  countries: Country[];
+  onSelectCountry: (countryCode: string) => void;
+  selectedCountry?: string;
+  headerText?: string;
+  maxHeight?: string | number;
+  width?: string | number;
+}


### PR DESCRIPTION
The CountryListDropdown was implemented, splitting it into atoms (flag, text, button), molecules (scrollable list with selection), and organisms (interactive dropdown). The UI was optimized with Material UI, adding keyboard navigation, visual highlighting, and efficient state management. Unit tests verify selection, interaction, and scrolling behavior.
![Captura de pantalla (1250)](https://github.com/user-attachments/assets/59321257-1974-4ebc-9da5-3adea9ef023e)
