### PR TITLE
feat: use matrial UI media queries

### DIFF
--- a/docs/breakpoints.md
+++ b/docs/breakpoints.md
@@ -1,0 +1,120 @@
+# Responsive Breakpoints and useBreakpoint Hook Usage
+
+## Available Breakpoints
+
+- MUI standard aliases:  
+  `xs`, `sm`, `md`, `lg`, `xl`
+
+- Custom breakpoints:  
+  `small-mobile`, `small-mobile-large`, `large-tablet`
+
+## Hook Signature
+
+```ts
+useBreakpoint(key: BreakpointAlias, direction: 'min' | 'max' = 'min'): boolean
+```
+
+- `key`: any of the breakpoint aliases above  
+- `direction`: `'min'` for `(min-width)` queries, `'max'` for `(max-width)`
+
+# Import paths summary
+
+```ts
+import { breakpoints } from './breakpoints'; // breakpoint values
+import { useBreakpoint } from './media-queries'; // hook for breakpoints
+import { theme } from './theme'; // theme with breakpoint integration
+```
+
+
+## How to Use
+
+```tsx
+import { useBreakpoint } from './media-queries';
+
+function Example() {
+  const isMobile = useBreakpoint('sm', 'max'); // screen ≤ sm breakpoint
+  const isTabletUp = useBreakpoint('md', 'min'); // screen ≥ md breakpoint
+  const isSmallMobile = useBreakpoint('small-mobile', 'max');
+  const isLargeTabletUp = useBreakpoint('large-tablet', 'min');
+
+  return (
+    <>
+      {isMobile && <p>Mobile screen or smaller</p>}
+      {isTabletUp && <p>Tablet or larger</p>}
+      {isSmallMobile && <p>Small mobile device detected</p>}
+      {isLargeTabletUp && <p>Large tablet or bigger</p>}
+    </>
+  );
+}
+```
+
+## Notes
+
+- Use `'min'` to check if viewport is at least the given breakpoint.  
+- Use `'max'` to check if viewport is up to the given breakpoint.  
+- Custom breakpoints behave exactly like standard MUI breakpoints in the hook.  
+- Avoid hardcoding pixel values; always use this centralized system.
+
+---
+
+This setup improves maintainability and consistency across your responsive design code.
+
+Using Breakpoints in Styling
+Material UI's theme.breakpoints.up() and theme.breakpoints.down() support only the MUI standard keys (xs, sm, md, lg, xl). For custom breakpoints, use raw media queries.
+
+<Box
+  sx={{
+    fontSize: '14px',
+    [theme.breakpoints.up('md')]: {
+      fontSize: '16px',
+    },
+  }}
+>
+  Responsive Text
+</Box>
+
+# Example for custom breakpoint in sx prop
+
+<Box
+  sx={{
+    fontSize: '14px',
+    '@media (min-width: 568px)': { // small-mobile-large custom breakpoint
+      fontSize: '16px',
+    },
+  }}
+>
+  Custom Breakpoint Text
+</Box>
+
+# Additional Examples
+# Responsive Button
+```ts
+
+import { Button } from '@mui/material';
+import { useBreakpoint } from './media-queries';
+
+function ResponsiveButton() {
+  const isLargeScreen = useBreakpoint('lg', 'min');
+  return (
+    <Button size={isLargeScreen ? 'large' : 'medium'}>
+      Click me
+    </Button>
+  );
+}
+```
+# Conditionally render content based on breakpoints
+
+```ts
+
+import { Typography } from '@mui/material';
+import { useBreakpoint } from './media-queries';
+
+function ResponsiveMessage() {
+  const isSmallMobile = useBreakpoint('small-mobile', 'max');
+  return (
+    <Typography variant="body1" color={isSmallMobile ? 'error' : 'textPrimary'}>
+      {isSmallMobile ? 'You are on a small mobile device' : 'Standard view'}
+    </Typography>
+  );
+}
+```

--- a/src/layouts/screen-size-rules/breakpoints.ts
+++ b/src/layouts/screen-size-rules/breakpoints.ts
@@ -1,16 +1,34 @@
-export const breakpoints = {
-  xs: 0,
-  'small-mobile': 320,
-  sm: 480,
-  'small-mobile-large': 568,
-  md: 768,
-  lg: 1024,
-  'large-tablet': 1112,
-  xl: 1280,
+import tokens from '../../style-library/themes/tokens/tokens.json';
+
+const mapKeys: Record<string, string> = {
+  small: 'sm',
+  medium: 'md',
+  large: 'lg',
+  extra_large: 'xl',
+  small_mobile: 'small-mobile',
+  small_mobile_large: 'small-mobile-large',
+  large_tablet: 'large-tablet',
 };
+
+const raw: Record<string, string> = tokens.breakpoints;
+
+export const breakpoints: Record<string, number> = Object.entries(raw).reduce<
+  Record<string, number>
+>((acc, [k, v]) => {
+  const key = mapKeys[k] ?? k.replace(/_/g, '-');
+  acc[key] = parseInt(v.replace('px', ''), 10);
+  return acc;
+}, {});
 
 export const breakpointValues = {
-  values: breakpoints,
+  values: {
+    xs: 0,
+    sm: breakpoints.sm,
+    md: breakpoints.md,
+    lg: breakpoints.lg,
+    xl: breakpoints.xl,
+    'small-mobile': breakpoints['small-mobile'],
+    'small-mobile-large': breakpoints['small-mobile-large'],
+    'large-tablet': breakpoints['large-tablet'],
+  },
 };
-
-export type BreakpointKey = keyof typeof breakpoints;

--- a/src/layouts/screen-size-rules/breakpoints.ts
+++ b/src/layouts/screen-size-rules/breakpoints.ts
@@ -1,11 +1,16 @@
 export const breakpoints = {
   xs: 0,
+  'small-mobile': 320,
   sm: 480,
+  'small-mobile-large': 568,
   md: 768,
   lg: 1024,
+  'large-tablet': 1112,
   xl: 1280,
 };
 
 export const breakpointValues = {
   values: breakpoints,
 };
+
+export type BreakpointKey = keyof typeof breakpoints;

--- a/src/layouts/screen-size-rules/breakpoints.ts
+++ b/src/layouts/screen-size-rules/breakpoints.ts
@@ -1,0 +1,11 @@
+export const breakpoints = {
+  xs: 0,
+  sm: 480,
+  md: 768,
+  lg: 1024,
+  xl: 1280,
+};
+
+export const breakpointValues = {
+  values: breakpoints,
+};

--- a/src/layouts/screen-size-rules/media-queries.stories.tsx
+++ b/src/layouts/screen-size-rules/media-queries.stories.tsx
@@ -2,14 +2,7 @@ import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { ThemeProvider, CssBaseline, Typography, Box, Button, Paper } from '@mui/material';
 import { theme } from './theme';
-import {
-  useIsMobile,
-  useIsTabletUp,
-  useIsDesktopDown,
-  useIsSmallMobileDown,
-  useIsSmallMobileLargeUp,
-  useIsLargeTabletUp,
-} from './media-queries';
+import { useBreakpoint } from './media-queries';
 
 const meta: Meta = {
   title: 'Theme/MediaQueriesMUI',
@@ -18,12 +11,12 @@ const meta: Meta = {
 export default meta;
 
 function ResponsiveTypographyDemoComponent() {
-  const isMobile = useIsMobile();
-  const isTabletUp = useIsTabletUp();
-  const isDesktopDown = useIsDesktopDown();
-  const isSmallMobileDown = useIsSmallMobileDown();
-  const isSmallMobileLargeUp = useIsSmallMobileLargeUp();
-  const isLargeTabletUp = useIsLargeTabletUp();
+  const isMobile = useBreakpoint('sm', 'max');
+  const isTabletUp = useBreakpoint('md', 'min');
+  const isDesktopDown = useBreakpoint('lg', 'max');
+  const isSmallMobileDown = useBreakpoint('small-mobile', 'max');
+  const isSmallMobileLargeUp = useBreakpoint('small-mobile-large', 'min');
+  const isLargeTabletUp = useBreakpoint('large-tablet', 'min');
 
   return (
     <Box sx={{ p: 2, bgcolor: '#f9f9f9' }}>
@@ -45,8 +38,7 @@ function ResponsiveTypographyDemoComponent() {
         component={Paper}
         elevation={2}
         sx={{
-          display: 'flex',
-          flexDirection: isTabletUp ? 'row' : 'column',
+          display: isTabletUp ? 'row' : 'column',
           gap: 3,
           p: 2,
           mb: 3,

--- a/src/layouts/screen-size-rules/media-queries.stories.tsx
+++ b/src/layouts/screen-size-rules/media-queries.stories.tsx
@@ -2,7 +2,14 @@ import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { ThemeProvider, CssBaseline, Typography, Box, Button, Paper } from '@mui/material';
 import { theme } from './theme';
-import { useIsMobile, useIsTabletUp, useIsDesktopDown } from './media-queries';
+import {
+  useIsMobile,
+  useIsTabletUp,
+  useIsDesktopDown,
+  useIsSmallMobileDown,
+  useIsSmallMobileLargeUp,
+  useIsLargeTabletUp,
+} from './media-queries';
 
 const meta: Meta = {
   title: 'Theme/MediaQueriesMUI',
@@ -14,6 +21,9 @@ function ResponsiveTypographyDemoComponent() {
   const isMobile = useIsMobile();
   const isTabletUp = useIsTabletUp();
   const isDesktopDown = useIsDesktopDown();
+  const isSmallMobileDown = useIsSmallMobileDown();
+  const isSmallMobileLargeUp = useIsSmallMobileLargeUp();
+  const isLargeTabletUp = useIsLargeTabletUp();
 
   return (
     <Box sx={{ p: 2, bgcolor: '#f9f9f9' }}>
@@ -69,6 +79,22 @@ function ResponsiveTypographyDemoComponent() {
               </Typography>
             ))}
           </Box>
+
+          {isSmallMobileDown && (
+            <Typography variant="caption" color="error.main" sx={{ mt: 1, display: 'block' }}>
+              You are on a very small mobile device (≤ 320px).
+            </Typography>
+          )}
+          {isSmallMobileLargeUp && (
+            <Typography variant="caption" color="success.main" sx={{ mt: 1, display: 'block' }}>
+              Your screen is at least 568px wide.
+            </Typography>
+          )}
+          {isLargeTabletUp && (
+            <Typography variant="caption" color="info.main" sx={{ mt: 1, display: 'block' }}>
+              Tablet or larger (≥ 1112px) detected.
+            </Typography>
+          )}
         </Box>
       </Box>
 

--- a/src/layouts/screen-size-rules/media-queries.stories.tsx
+++ b/src/layouts/screen-size-rules/media-queries.stories.tsx
@@ -1,0 +1,169 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { ThemeProvider, CssBaseline, Typography, Box, Button, Paper } from '@mui/material';
+import { theme } from './theme';
+import { useIsMobile, useIsTabletUp, useIsDesktopDown } from './media-queries';
+
+const meta: Meta = {
+  title: 'Theme/MediaQueriesMUI',
+  component: Typography,
+};
+export default meta;
+
+function ResponsiveTypographyDemoComponent() {
+  const isMobile = useIsMobile();
+  const isTabletUp = useIsTabletUp();
+  const isDesktopDown = useIsDesktopDown();
+
+  return (
+    <Box sx={{ p: 2, bgcolor: '#f9f9f9' }}>
+      <Paper elevation={3} sx={{ p: 2, mb: 3 }}>
+        <Box textAlign="center">
+          <Typography variant="h1" gutterBottom>
+            Welcome to Our Site
+          </Typography>
+          <Typography variant="subtitle1">Delivering awesome experiences on any device</Typography>
+          <Box mt={2}>
+            <Button variant="contained" size="large">
+              Get Started
+            </Button>
+          </Box>
+        </Box>
+      </Paper>
+
+      <Box
+        component={Paper}
+        elevation={2}
+        sx={{
+          display: 'flex',
+          flexDirection: isTabletUp ? 'row' : 'column',
+          gap: 3,
+          p: 2,
+          mb: 3,
+        }}
+      >
+        <Box flex={1} textAlign={isMobile ? 'center' : 'left'}>
+          <Typography variant="h4" gutterBottom>
+            Our Mission
+          </Typography>
+          <Typography variant="body1" paragraph>
+            We aim to create responsive, high-performance user interfaces that work on all devices.
+          </Typography>
+          <Typography variant="body2">
+            Learn more about how we build scalable front-end architectures and clean codebases.
+          </Typography>
+        </Box>
+
+        <Box flex={1} textAlign={isMobile ? 'center' : 'left'}>
+          <Typography variant="h5" gutterBottom>
+            Key Features
+          </Typography>
+          <Box component="ul" sx={{ pl: isMobile ? 2 : 3, m: 0 }}>
+            {[
+              'Fluid typography that scales with viewport',
+              'Custom breakpoints for fine-tuned layouts',
+              'Hooks for conditional rendering',
+            ].map((text) => (
+              <Typography component="li" variant="body1" key={text}>
+                {text}
+              </Typography>
+            ))}
+          </Box>
+        </Box>
+      </Box>
+
+      <Paper elevation={1} sx={{ p: 1, textAlign: 'center' }}>
+        <Typography variant="caption">© 2025 Your Company. All rights reserved.</Typography>
+        {isDesktopDown && (
+          <Typography variant="caption" sx={{ display: 'block', mt: 0.5 }}>
+            Viewing on desktop or smaller screen.
+          </Typography>
+        )}
+        {isMobile && (
+          <Typography variant="caption" sx={{ display: 'block', mt: 0.5, color: 'primary.main' }}>
+            Viewing on mobile device.
+          </Typography>
+        )}
+      </Paper>
+    </Box>
+  );
+}
+
+export const ResponsiveTypographyDemo: StoryObj = {
+  render: () => (
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <ResponsiveTypographyDemoComponent />
+    </ThemeProvider>
+  ),
+};
+
+function HeroImageComponent() {
+  return (
+    <div
+      style={{
+        width: '100%',
+        height: '100dvh',
+        maxHeight: '100dvh',
+        position: 'relative',
+        overflow: 'hidden',
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        alignItems: 'center',
+      }}
+    >
+      <img
+        src="https://nicolaslule.com/wp-content/uploads/hero-image-flex-example-1.jpg"
+        alt="Hero"
+        style={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          width: '100%',
+          height: '100%',
+          objectFit: 'cover',
+          objectPosition: 'center',
+          zIndex: -1,
+        }}
+      />
+
+      <div
+        style={{
+          position: 'relative',
+          zIndex: 1,
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center',
+          alignItems: 'center',
+          textAlign: 'center',
+          padding: '32px',
+          maxWidth: 800,
+          margin: '0 auto',
+          overflow: 'hidden',
+          backgroundColor: 'rgba(0, 0, 0, 0.45)',
+          borderRadius: '8px',
+        }}
+      >
+        <Typography variant="h1" color="common.white" gutterBottom>
+          Discover Your Adventure
+        </Typography>
+        <Typography variant="h5" color="common.white" gutterBottom>
+          Experience breathtaking views anywhere, anytime.
+        </Typography>
+        <Button variant="contained" size="large">
+          Explore Now
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export const FullscreenHeroExample = {
+  render: () => (
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <HeroImageComponent />
+    </ThemeProvider>
+  ),
+};

--- a/src/layouts/screen-size-rules/media-queries.ts
+++ b/src/layouts/screen-size-rules/media-queries.ts
@@ -2,56 +2,33 @@ import { useTheme, useMediaQuery } from '@mui/material';
 import type { Breakpoint } from '@mui/material';
 import { breakpoints } from './breakpoints';
 
-type CustomBreakpointKey = keyof typeof breakpoints;
+type BreakpointAlias =
+  | 'xs'
+  | 'sm'
+  | 'md'
+  | 'lg'
+  | 'xl'
+  | 'small-mobile'
+  | 'small-mobile-large'
+  | 'large-tablet';
+type Direction = 'min' | 'max';
 
-export function useBreakpoint(key: CustomBreakpointKey, direction: 'up' | 'down' = 'up'): boolean {
+export function useBreakpoint(key: BreakpointAlias, direction: Direction = 'min'): boolean {
   const theme = useTheme();
-
-  const isOfficialBreakpoint = ['xs', 'sm', 'md', 'lg', 'xl'].includes(key);
+  const isMUIKey = ['xs', 'sm', 'md', 'lg', 'xl'].includes(key);
 
   let query: string;
 
-  if (isOfficialBreakpoint) {
-    if (direction === 'up') {
-      query = theme.breakpoints.up(key as Breakpoint);
-    } else {
-      query = theme.breakpoints.down(key as Breakpoint);
-    }
+  if (isMUIKey) {
+    query =
+      direction === 'min'
+        ? theme.breakpoints.up(key as Breakpoint)
+        : theme.breakpoints.down(key as Breakpoint);
   } else {
-    const px = breakpoints[key];
-    if (direction === 'up') {
-      query = `(min-width: ${px.toString()}px)`;
-    } else {
-      query = `(max-width: ${(px - 0.05).toString()}px)`;
-    }
+    const px: number = breakpoints[key];
+    query =
+      direction === 'min' ? `(min-width: ${String(px)}px)` : `(max-width: ${String(px - 0.05)}px)`;
   }
 
   return useMediaQuery(query);
 }
-
-export const useIsXsDown = () => useBreakpoint('xs', 'down');
-export const useIsSmDown = () => useBreakpoint('sm', 'down');
-export const useIsMdDown = () => useBreakpoint('md', 'down');
-export const useIsLgDown = () => useBreakpoint('lg', 'down');
-export const useIsXlDown = () => useBreakpoint('xl', 'down');
-export const useIsSmallMobileDown = () => useBreakpoint('small-mobile', 'down');
-export const useIsSmallMobileLargeDown = () => useBreakpoint('small-mobile-large', 'down');
-export const useIsLargeTabletDown = () => useBreakpoint('large-tablet', 'down');
-
-export const useIsXsUp = () => useBreakpoint('xs', 'up');
-export const useIsSmUp = () => useBreakpoint('sm', 'up');
-export const useIsMdUp = () => useBreakpoint('md', 'up');
-export const useIsLgUp = () => useBreakpoint('lg', 'up');
-export const useIsXlUp = () => useBreakpoint('xl', 'up');
-export const useIsSmallMobileUp = () => useBreakpoint('small-mobile', 'up');
-export const useIsSmallMobileLargeUp = () => useBreakpoint('small-mobile-large', 'up');
-export const useIsLargeTabletUp = () => useBreakpoint('large-tablet', 'up');
-
-export const useIsMobile = () => useBreakpoint('sm', 'down');
-export const useIsTabletUp = () => useBreakpoint('md', 'up');
-export const useIsTabletDown = () => useBreakpoint('md', 'down');
-export const useIsDesktopUp = () => useBreakpoint('lg', 'up');
-export const useIsDesktopDown = () => useBreakpoint('lg', 'down');
-export const useIsSmallMobile = () => useBreakpoint('small-mobile', 'down');
-export const useIsSmallMobileLarge = () => useBreakpoint('small-mobile-large', 'down');
-export const useIsLargeTablet = () => useBreakpoint('large-tablet', 'down');

--- a/src/layouts/screen-size-rules/media-queries.ts
+++ b/src/layouts/screen-size-rules/media-queries.ts
@@ -1,9 +1,31 @@
 import { useTheme, useMediaQuery } from '@mui/material';
 import type { Breakpoint } from '@mui/material';
+import { breakpoints } from './breakpoints';
 
-function useBreakpoint(key: Breakpoint, direction: 'up' | 'down' = 'up'): boolean {
+type CustomBreakpointKey = keyof typeof breakpoints;
+
+function useBreakpoint(key: CustomBreakpointKey, direction: 'up' | 'down' = 'up'): boolean {
   const theme = useTheme();
-  const query = direction === 'up' ? theme.breakpoints.up(key) : theme.breakpoints.down(key);
+
+  const isOfficialBreakpoint = ['xs', 'sm', 'md', 'lg', 'xl'].includes(key);
+
+  let query: string;
+
+  if (isOfficialBreakpoint) {
+    if (direction === 'up') {
+      query = theme.breakpoints.up(key as Breakpoint);
+    } else {
+      query = theme.breakpoints.down(key as Breakpoint);
+    }
+  } else {
+    const px = breakpoints[key];
+    if (direction === 'up') {
+      query = `(min-width: ${px.toString()}px)`;
+    } else {
+      query = `(max-width: ${(px - 0.05).toString()}px)`;
+    }
+  }
+
   return useMediaQuery(query);
 }
 
@@ -12,15 +34,24 @@ export const useIsSmDown = () => useBreakpoint('sm', 'down');
 export const useIsMdDown = () => useBreakpoint('md', 'down');
 export const useIsLgDown = () => useBreakpoint('lg', 'down');
 export const useIsXlDown = () => useBreakpoint('xl', 'down');
+export const useIsSmallMobileDown = () => useBreakpoint('small-mobile', 'down');
+export const useIsSmallMobileLargeDown = () => useBreakpoint('small-mobile-large', 'down');
+export const useIsLargeTabletDown = () => useBreakpoint('large-tablet', 'down');
 
 export const useIsXsUp = () => useBreakpoint('xs', 'up');
 export const useIsSmUp = () => useBreakpoint('sm', 'up');
 export const useIsMdUp = () => useBreakpoint('md', 'up');
 export const useIsLgUp = () => useBreakpoint('lg', 'up');
 export const useIsXlUp = () => useBreakpoint('xl', 'up');
+export const useIsSmallMobileUp = () => useBreakpoint('small-mobile', 'up');
+export const useIsSmallMobileLargeUp = () => useBreakpoint('small-mobile-large', 'up');
+export const useIsLargeTabletUp = () => useBreakpoint('large-tablet', 'up');
 
-export const useIsMobile = () => useIsSmDown();
-export const useIsTabletUp = () => useIsMdUp();
-export const useIsTabletDown = () => useIsMdDown();
-export const useIsDesktopUp = () => useIsLgUp();
-export const useIsDesktopDown = () => useIsLgDown();
+export const useIsMobile = () => useBreakpoint('sm', 'down');
+export const useIsTabletUp = () => useBreakpoint('md', 'up');
+export const useIsTabletDown = () => useBreakpoint('md', 'down');
+export const useIsDesktopUp = () => useBreakpoint('lg', 'up');
+export const useIsDesktopDown = () => useBreakpoint('lg', 'down');
+export const useIsSmallMobile = () => useBreakpoint('small-mobile', 'down');
+export const useIsSmallMobileLarge = () => useBreakpoint('small-mobile-large', 'down');
+export const useIsLargeTablet = () => useBreakpoint('large-tablet', 'down');

--- a/src/layouts/screen-size-rules/media-queries.ts
+++ b/src/layouts/screen-size-rules/media-queries.ts
@@ -1,0 +1,26 @@
+import { useTheme, useMediaQuery } from '@mui/material';
+import type { Breakpoint } from '@mui/material';
+
+function useBreakpoint(key: Breakpoint, direction: 'up' | 'down' = 'up'): boolean {
+  const theme = useTheme();
+  const query = direction === 'up' ? theme.breakpoints.up(key) : theme.breakpoints.down(key);
+  return useMediaQuery(query);
+}
+
+export const useIsXsDown = () => useBreakpoint('xs', 'down');
+export const useIsSmDown = () => useBreakpoint('sm', 'down');
+export const useIsMdDown = () => useBreakpoint('md', 'down');
+export const useIsLgDown = () => useBreakpoint('lg', 'down');
+export const useIsXlDown = () => useBreakpoint('xl', 'down');
+
+export const useIsXsUp = () => useBreakpoint('xs', 'up');
+export const useIsSmUp = () => useBreakpoint('sm', 'up');
+export const useIsMdUp = () => useBreakpoint('md', 'up');
+export const useIsLgUp = () => useBreakpoint('lg', 'up');
+export const useIsXlUp = () => useBreakpoint('xl', 'up');
+
+export const useIsMobile = () => useIsSmDown();
+export const useIsTabletUp = () => useIsMdUp();
+export const useIsTabletDown = () => useIsMdDown();
+export const useIsDesktopUp = () => useIsLgUp();
+export const useIsDesktopDown = () => useIsLgDown();

--- a/src/layouts/screen-size-rules/media-queries.ts
+++ b/src/layouts/screen-size-rules/media-queries.ts
@@ -4,7 +4,7 @@ import { breakpoints } from './breakpoints';
 
 type CustomBreakpointKey = keyof typeof breakpoints;
 
-function useBreakpoint(key: CustomBreakpointKey, direction: 'up' | 'down' = 'up'): boolean {
+export function useBreakpoint(key: CustomBreakpointKey, direction: 'up' | 'down' = 'up'): boolean {
   const theme = useTheme();
 
   const isOfficialBreakpoint = ['xs', 'sm', 'md', 'lg', 'xl'].includes(key);

--- a/src/layouts/screen-size-rules/theme.ts
+++ b/src/layouts/screen-size-rules/theme.ts
@@ -1,0 +1,10 @@
+import { createTheme } from '@mui/material/styles';
+import { breakpointValues } from './breakpoints';
+import { generateResponsiveTypography } from './typography-responsive';
+
+const theme = createTheme({
+  breakpoints: breakpointValues,
+  typography: generateResponsiveTypography(),
+});
+
+export { theme };

--- a/src/layouts/screen-size-rules/typography-responsive.ts
+++ b/src/layouts/screen-size-rules/typography-responsive.ts
@@ -1,0 +1,45 @@
+import type { TypographyVariantsOptions } from '@mui/material/styles';
+import { breakpoints } from './breakpoints';
+
+const baseSizes = {
+  h1: 1.5,
+  h2: 1.25,
+  h3: 1,
+  h4: 0.875,
+  h5: 0.75,
+  h6: 0.625,
+  body1: 0.875,
+  body2: 0.75,
+  subtitle1: 0.875,
+  subtitle2: 0.75,
+  button: 0.75,
+  caption: 0.625,
+  overline: 0.625,
+} as const;
+
+export function generateResponsiveTypography(): TypographyVariantsOptions {
+  const variants: TypographyVariantsOptions = {};
+
+  (Object.keys(baseSizes) as (keyof typeof baseSizes)[]).forEach((variant) => {
+    const baseSize = baseSizes[variant];
+
+    const styles: Record<string, string | Record<string, string>> = {
+      fontSize: `${baseSize.toFixed(3)}rem`,
+    };
+
+    Object.values(breakpoints).forEach((minWidth, i) => {
+      const minWidthStr = minWidth.toString();
+
+      styles[`@media (min-width:${minWidthStr}px)`] = {
+        fontSize: `${(baseSize + 0.25 * i).toFixed(3)}rem`,
+      };
+    });
+
+    if (variant === 'button') styles.textTransform = 'none';
+    if (variant === 'overline') styles.textTransform = 'uppercase';
+
+    variants[variant] = styles;
+  });
+
+  return variants;
+}

--- a/src/layouts/screen-size-rules/typography-responsive.ts
+++ b/src/layouts/screen-size-rules/typography-responsive.ts
@@ -1,5 +1,5 @@
 import type { TypographyVariantsOptions } from '@mui/material/styles';
-import { breakpoints } from './breakpoints';
+import { breakpointValues } from './breakpoints';
 
 const baseSizes = {
   h1: 1.5,
@@ -20,7 +20,7 @@ const baseSizes = {
 export function generateResponsiveTypography(): TypographyVariantsOptions {
   const variants: TypographyVariantsOptions = {};
 
-  const sortedBreakpoints = Object.entries(breakpoints).sort(([, a], [, b]) => a - b);
+  const sortedBreakpoints = Object.entries(breakpointValues.values).sort(([, a], [, b]) => a - b);
 
   (Object.keys(baseSizes) as (keyof typeof baseSizes)[]).forEach((variant) => {
     const baseSize = baseSizes[variant];
@@ -29,10 +29,13 @@ export function generateResponsiveTypography(): TypographyVariantsOptions {
       fontSize: `${baseSize.toFixed(3)}rem`,
     };
 
-    sortedBreakpoints.forEach(([, minWidth], i) => {
-      styles[`@media (min-width:${minWidth.toString()}px)`] = {
-        fontSize: `${(baseSize + 0.25 * i).toFixed(3)}rem`,
-      };
+    sortedBreakpoints.forEach(([, minWidth], index) => {
+      if (minWidth > 0) {
+        const mediaQuery = `@media (min-width: ${minWidth.toString()}px)`;
+        styles[mediaQuery] = {
+          fontSize: `${(baseSize + 0.25 * index).toFixed(3)}rem`,
+        };
+      }
     });
 
     if (variant === 'button') styles.textTransform = 'none';

--- a/src/layouts/screen-size-rules/typography-responsive.ts
+++ b/src/layouts/screen-size-rules/typography-responsive.ts
@@ -20,6 +20,8 @@ const baseSizes = {
 export function generateResponsiveTypography(): TypographyVariantsOptions {
   const variants: TypographyVariantsOptions = {};
 
+  const sortedBreakpoints = Object.entries(breakpoints).sort(([, a], [, b]) => a - b);
+
   (Object.keys(baseSizes) as (keyof typeof baseSizes)[]).forEach((variant) => {
     const baseSize = baseSizes[variant];
 
@@ -27,10 +29,8 @@ export function generateResponsiveTypography(): TypographyVariantsOptions {
       fontSize: `${baseSize.toFixed(3)}rem`,
     };
 
-    Object.values(breakpoints).forEach((minWidth, i) => {
-      const minWidthStr = minWidth.toString();
-
-      styles[`@media (min-width:${minWidthStr}px)`] = {
+    sortedBreakpoints.forEach(([, minWidth], i) => {
+      styles[`@media (min-width:${minWidth.toString()}px)`] = {
         fontSize: `${(baseSize + 0.25 * i).toFixed(3)}rem`,
       };
     });


### PR DESCRIPTION
#sumary
Implementation of custom breakpoints for the project. We also made the typography responsive because MUI’s default font sizes didn’t fit well with our custom screen sizes. Sorry about the typography part — it wasn’t in the plan initially, but we had to do it so everything looks good on all devices.
#354 
https://ditmar.github.io/OpenScience/feature-FRONTEND-354/
#screenshot
![image](https://github.com/user-attachments/assets/250c0499-93cb-4b1c-8575-259bf7f2a77f)
![image](https://github.com/user-attachments/assets/024614a8-b73c-43c1-a8af-d731dde3a5a8)
