### PR TITLE
bugfix(OLItem): fix TypeScript error in borderRadius by casting to nu…

### DIFF
--- a/src/ui/components/atoms/ol-item/OLItem.style.ts
+++ b/src/ui/components/atoms/ol-item/OLItem.style.ts
@@ -17,7 +17,7 @@ export const OLItemRoot = styled(Box, {
     borderRadius: '0',
   }),
   ...(shape === 'rounded' && {
-    borderRadius: theme.shape.borderRadius + 4,
+    borderRadius: (theme.shape.borderRadius as number) + 4,
   }),
   ...(shape === 'circle' && {
     borderRadius: '50%',


### PR DESCRIPTION
**What does this PR do?**

This PR **fixes a TypeScript error** in `src/ui/components/atoms/ol-item/OLItem.style.ts` by **casting `theme.shape.borderRadius` to a `number`** to ensure safe addition with `4`.

**Why?**

This change **resolves the following error** encountered during build/lint processes:

Operands of '+' operations must be a number or string. Got string | number + number


**How?**

The affected line was updated to:

```typescript
borderRadius: (theme.shape.borderRadius as number) + 4,