### PR TITLE
feat: Add YearSelector molecule component with fullscreen background

### DIFF
--- a/src/library/component/molecules/year-selector/__mock__/datamock.json
+++ b/src/library/component/molecules/year-selector/__mock__/datamock.json
@@ -1,0 +1,137 @@
+{
+  "data": [
+    {
+      "id": 1,
+      "attributes": {
+        "Year": "2023",
+        "Volumes": "1"
+      }
+    },
+    {
+      "id": 2,
+      "attributes": {
+        "Year": "2024",
+        "Volumes": "2"
+      }
+    },
+    {
+      "id": 3,
+      "attributes": {
+        "Year": "2025",
+        "Volumes": "1"
+      }
+    },
+    {
+      "id": 4,
+      "attributes": {
+        "Year": "2026",
+        "Volumes": "2"
+      }
+    },
+    {
+      "id": 5,
+      "attributes": {
+        "Year": "2027",
+        "Volumes": "1"
+      }
+    },
+    {
+      "id": 6,
+      "attributes": {
+        "Year": "2028",
+        "Volumes": "2"
+      }
+    },
+    {
+      "id": 7,
+      "attributes": {
+        "Year": "2029",
+        "Volumes": "1"
+      }
+    },
+    {
+      "id": 8,
+      "attributes": {
+        "Year": "2030",
+        "Volumes": "2"
+      }
+    },
+    {
+      "id": 9,
+      "attributes": {
+        "Year": "2031",
+        "Volumes": "1"
+      }
+    },
+    {
+      "id": 10,
+      "attributes": {
+        "Year": "2032",
+        "Volumes": "2"
+      }
+    },
+    {
+      "id": 11,
+      "attributes": {
+        "Year": "2033",
+        "Volumes": "1"
+      }
+    },
+    {
+      "id": 12,
+      "attributes": {
+        "Year": "2034",
+        "Volumes": "2"
+      }
+    },
+    {
+      "id": 13,
+      "attributes": {
+        "Year": "2035",
+        "Volumes": "1"
+      }
+    },
+    {
+      "id": 14,
+      "attributes": {
+        "Year": "2036",
+        "Volumes": "2"
+      }
+    },
+    {
+      "id": 15,
+      "attributes": {
+        "Year": "2037",
+        "Volumes": "1"
+      }
+    },
+    {
+      "id": 16,
+      "attributes": {
+        "Year": "2038",
+        "Volumes": "2"
+      }
+    },
+    {
+      "id": 17,
+      "attributes": {
+        "Year": "2039",
+        "Volumes": "1"
+      }
+    },
+    {
+      "id": 18,
+      "attributes": {
+        "Year": "2040",
+        "Volumes": "2"
+      }
+    },
+    {
+      "id": 19,
+      "attributes": {
+        "Year": "2041",
+        "Volumes": "1"
+      }
+    }
+  ]
+}

--- a/src/library/component/molecules/year-selector/types/IProps.ts
+++ b/src/library/component/molecules/year-selector/types/IProps.ts
@@ -1,0 +1,15 @@
+export interface IAttributes {
+  Year: string;
+  Volumes: string;
+}
+
+export interface IData {
+  id: number;
+  attributes: IAttributes;
+}
+
+export interface IProps {
+  data: IData[];
+  initialYear?: string;
+  backgroundImage: string;
+}

--- a/src/library/component/molecules/year-selector/year-selector.stories.tsx
+++ b/src/library/component/molecules/year-selector/year-selector.stories.tsx
@@ -1,0 +1,24 @@
+import type { StoryObj, Meta } from '@storybook/react';
+import YearSelector from './year-selector';
+import Rectangle12 from '../../../../ui/components/atoms/hero-banner/__mock__/imgs/Rectangle12.png';
+import dataMock from './__mock__/datamock.json';
+
+const meta: Meta<typeof YearSelector> = {
+  title: 'library/component/molecules/year-selector',
+  component: YearSelector,
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof YearSelector>;
+
+export const Default: Story = {
+  args: {
+    data: dataMock.data,
+    initialYear: 'AÑO',
+    backgroundImage: String(Rectangle12),
+  },
+};

--- a/src/library/component/molecules/year-selector/year-selector.styles.ts
+++ b/src/library/component/molecules/year-selector/year-selector.styles.ts
@@ -1,0 +1,50 @@
+import { styled } from '@mui/material/styles';
+
+export const YearSelectorContainer = styled('div')({
+  position: 'relative',
+  width: '100vw',
+  height: '100vh',
+  overflow: 'hidden',
+});
+
+export const YearSelectorWrapper = styled('div')(({ theme }) => ({
+  position: 'absolute',
+  top: theme.spacing(-1),
+  left: theme.spacing(0.75),
+  zIndex: 2,
+  width: '100vw',
+  padding: theme.spacing(2),
+}));
+
+export const YearListContainer = styled('div')<{ hidden?: boolean }>(({ theme, hidden }) => ({
+  display: hidden ? 'none' : 'flex',
+  flexWrap: 'wrap',
+  gap: theme.spacing(1),
+  marginTop: theme.spacing(2),
+  borderRadius: theme.shape.borderRadius,
+  maxHeight: '80vh',
+  overflowY: 'auto',
+  padding: theme.spacing(1),
+
+  '&::-webkit-scrollbar': {
+    width: theme.spacing(0.75),
+  },
+  '&::-webkit-scrollbar-track': {
+    background: theme.palette.grey[200],
+  },
+  '&::-webkit-scrollbar-thumb': {
+    background: theme.palette.primary.main,
+    borderRadius: theme.spacing(0.375),
+  },
+}));
+
+export const FullScreenHero = styled('div')({
+  position: 'fixed',
+  top: 0,
+  left: 0,
+  width: '100vw',
+  height: '100vh',
+  zIndex: 1,
+  backgroundSize: 'cover',
+  backgroundPosition: 'center',
+});

--- a/src/library/component/molecules/year-selector/year-selector.test.tsx
+++ b/src/library/component/molecules/year-selector/year-selector.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import YearSelector from './year-selector';
+import type { IData } from './types/IProps';
+
+const mockData: IData[] = [
+  { id: 1, attributes: { Year: '2020', Volumes: '10' } },
+  { id: 2, attributes: { Year: '2021', Volumes: '12' } },
+  { id: 3, attributes: { Year: '2022', Volumes: '15' } },
+];
+
+const mockBackgroundImage = 'mock-background-image.png';
+
+describe('YearSelector Component', () => {
+  test('renderiza con año inicial y botón visible', () => {
+    render(
+      <YearSelector data={mockData} initialYear="AÑO" backgroundImage={mockBackgroundImage} />,
+    );
+
+    expect(screen.getByRole('button')).toHaveTextContent('AÑO');
+  });
+
+  test('muestra y oculta la lista de años al hacer clic en el botón', () => {
+    render(
+      <YearSelector data={mockData} initialYear="AÑO" backgroundImage={mockBackgroundImage} />,
+    );
+
+    const button = screen.getByRole('button');
+
+    expect(screen.queryByText('2020')).not.toBeVisible();
+
+    fireEvent.click(button);
+
+    expect(screen.getByText('2020')).toBeVisible();
+    expect(screen.getByText('2021')).toBeVisible();
+    expect(screen.getByText('2022')).toBeVisible();
+
+    fireEvent.click(button);
+    expect(screen.queryByText('2020')).not.toBeVisible();
+  });
+
+  test('selecciona un año y actualiza el botón, oculta la lista', () => {
+    render(
+      <YearSelector data={mockData} initialYear="AÑO" backgroundImage={mockBackgroundImage} />,
+    );
+
+    const button = screen.getByRole('button');
+
+    fireEvent.click(button);
+
+    const year2021 = screen.getByText('2021');
+    fireEvent.click(year2021);
+
+    expect(button).toHaveTextContent('2021');
+
+    expect(screen.queryByText('2020')).not.toBeVisible();
+  });
+});

--- a/src/library/component/molecules/year-selector/year-selector.tsx
+++ b/src/library/component/molecules/year-selector/year-selector.tsx
@@ -1,0 +1,52 @@
+import React, { useState } from 'react';
+import ButtonYear from '../../../../ui/components/atoms/button-year/ButtonYear';
+import Year from '../../../../ui/components/atoms/year/Year';
+import HeroBanner from '../../../../ui/components/atoms/hero-banner/HeroBanner';
+import type { IData, IProps } from './types/IProps';
+import {
+  YearSelectorContainer,
+  YearSelectorWrapper,
+  YearListContainer,
+  FullScreenHero,
+} from './year-selector.styles';
+
+function YearSelector({ data, initialYear = 'AÑO', backgroundImage }: IProps) {
+  const [years] = useState<IData[]>(data);
+  const [isListHidden, setIsListHidden] = useState(true);
+  const [selectedYear, setSelectedYear] = useState(initialYear);
+
+  const handleYearClick = (year: string) => {
+    setSelectedYear(year);
+    setIsListHidden(true);
+  };
+
+  const toggleYearList = () => {
+    setIsListHidden(!isListHidden);
+  };
+
+  return (
+    <YearSelectorContainer>
+      <HeroBanner backgroundImage={backgroundImage} alt="Background" className="hero-banner">
+        <FullScreenHero style={{ backgroundImage: `url(${backgroundImage})` }} />
+      </HeroBanner>
+      <YearSelectorWrapper>
+        <ButtonYear onClick={toggleYearList}>{selectedYear}</ButtonYear>
+        <YearListContainer hidden={isListHidden}>
+          {years.map(({ id, attributes }) => (
+            <Year
+              key={id}
+              onClick={() => {
+                handleYearClick(attributes.Year);
+              }}
+              aria-label={`Select year ${attributes.Year}`}
+            >
+              {attributes.Year}
+            </Year>
+          ))}
+        </YearListContainer>
+      </YearSelectorWrapper>
+    </YearSelectorContainer>
+  );
+}
+
+export default YearSelector;


### PR DESCRIPTION
**Descripción del Componente Year-Selector**  

**Molecula:** `YearSelector`   
**Propósito:** Selector de año con fondo de pantalla completo y lista desplegable.  
![image](https://github.com/user-attachments/assets/fb2410ba-d7c4-4847-8489-341b6ab09bf6)
---

### **Características Principales**  
✅ **Selector de Año:**    
- Al hacer clic, despliega una lista de años disponibles.  
![image](https://github.com/user-attachments/assets/ad5fc032-e751-48e1-bc48-dc80f6203757)
- Muestra el año seleccionado en un botón.  
![image](https://github.com/user-attachments/assets/13e069f8-1f90-49db-af24-3ce55a77ef9b)
