### PR TITLE
Feature/FRONTEND-244: `FilledButton`

### DIFF
--- a/src/ui/components/atoms/button-filled/ButtonFilled.stories.tsx
+++ b/src/ui/components/atoms/button-filled/ButtonFilled.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ButtonFilled } from './ButtonFilled';
+import type { IProps } from './types/IProps';
+
+const commonProps: Partial<IProps> = {
+  text: 'botón GOD',
+};
+
+const meta = {
+  title: 'ui/components/atoms/button-filled',
+  component: ButtonFilled,
+  args: {
+    ...commonProps,
+  },
+} as Meta<typeof ButtonFilled>;
+
+export default meta;
+
+type Story = StoryObj<typeof ButtonFilled>;
+
+export const Default: Story = {
+  args: {
+    ...commonProps,
+  },
+};

--- a/src/ui/components/atoms/button-filled/ButtonFilled.stories.tsx
+++ b/src/ui/components/atoms/button-filled/ButtonFilled.stories.tsx
@@ -3,7 +3,7 @@ import { ButtonFilled } from './ButtonFilled';
 import type { IProps } from './types/IProps';
 
 const commonProps: Partial<IProps> = {
-  text: 'botón GOD',
+  text: 'Button text',
 };
 
 const meta = {

--- a/src/ui/components/atoms/button-filled/ButtonFilled.stories.tsx
+++ b/src/ui/components/atoms/button-filled/ButtonFilled.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import CancelOutlinedIcon from '@mui/icons-material/CancelOutlined';
 import { ButtonFilled } from './ButtonFilled';
 import type { IProps } from './types/IProps';
 
@@ -12,14 +13,85 @@ const meta = {
   args: {
     ...commonProps,
   },
+  argTypes: {
+    startIcon: { control: false },
+    endIcon: { control: false },
+  },
 } as Meta<typeof ButtonFilled>;
 
 export default meta;
 
 type Story = StoryObj<typeof ButtonFilled>;
 
+export const Empty: Story = {
+  args: {
+    ...commonProps,
+  },
+};
+
+export const WithIcons: Story = {
+  args: {
+    ...commonProps,
+    startIcon: <CancelOutlinedIcon />,
+    endIcon: <CancelOutlinedIcon />,
+  },
+};
+
+export const LeftIcon: Story = {
+  args: {
+    ...commonProps,
+    startIcon: <CancelOutlinedIcon />,
+  },
+};
+
+export const RightIcon: Story = {
+  args: {
+    ...commonProps,
+    endIcon: <CancelOutlinedIcon />,
+  },
+};
+
 export const Default: Story = {
   args: {
     ...commonProps,
+    buttonVariant: 'default',
+    startIcon: <CancelOutlinedIcon />,
+    endIcon: <CancelOutlinedIcon />,
+  },
+};
+
+export const Ghost: Story = {
+  args: {
+    ...commonProps,
+    buttonVariant: 'ghost',
+    startIcon: <CancelOutlinedIcon />,
+    endIcon: <CancelOutlinedIcon />,
+  },
+};
+
+export const Light: Story = {
+  args: {
+    ...commonProps,
+    buttonVariant: 'light',
+    startIcon: <CancelOutlinedIcon />,
+    endIcon: <CancelOutlinedIcon />,
+  },
+};
+
+export const Soft: Story = {
+  args: {
+    ...commonProps,
+    buttonVariant: 'soft',
+    startIcon: <CancelOutlinedIcon />,
+    endIcon: <CancelOutlinedIcon />,
+  },
+};
+
+export const Outline: Story = {
+  args: {
+    ...commonProps,
+    buttonVariant: 'outline',
+    startIcon: <CancelOutlinedIcon />,
+    endIcon: <CancelOutlinedIcon />,
   },
 };

--- a/src/ui/components/atoms/button-filled/ButtonFilled.styles.ts
+++ b/src/ui/components/atoms/button-filled/ButtonFilled.styles.ts
@@ -2,86 +2,87 @@ import type { SxProps, Theme } from '@mui/material';
 import { theme } from '../../../../globals/theme';
 
 const borderRadiusMap = {
-    normal: '0',
-    semi: '0.5rem',
-    circle: '3.125rem',
+  normal: '0',
+  semi: '0.5rem',
+  circle: '3.125rem',
 } as const;
 
 const fontSizeMap = {
-    small: '1rem',
-    medium: '1.125rem',
-    large: '1.25rem',
+  small: '1rem',
+  medium: '1.125rem',
+  large: '1.25rem',
 } as const;
 
 const iconSizeMap = {
-    small: '1.125rem',
-    medium: '1.25rem',
-    large: '1.5rem',
+  small: '1.125rem',
+  medium: '1.25rem',
+  large: '1.5rem',
 } as const;
 
 const buttonColorDefaultMap = {
-    white: theme.colors.neutral.white[900],
-    black: theme.colors.neutral.black[500],
-    grayStrongDark: theme.colors.neutral.grayStrongDark[500],
-    graySoft: theme.colors.neutral.graySoft[500],
-    primary: theme.colors.brand.primary[500],
-    secondary: theme.colors.brand.secondary[500],
-    tertiary: theme.colors.brand.tertiary[500],
-    positive: theme.colors.feedback.positive[500],
-    negative: theme.colors.feedback.negative[500],
-    warning: theme.colors.feedback.warning[500],
-    disabled: theme.colors.neutral.grayStrongDark[50],
-} as const;
-
-const buttonColorSoftMap = {
-    white: theme.colors.neutral.white[900],
-    black: theme.colors.neutral.black[100],
-    grayStrongDark: theme.colors.neutral.grayStrongDark[100],
-    graySoft: theme.colors.neutral.graySoft[100],
-    primary: theme.colors.brand.primary[100],
-    secondary: theme.colors.brand.secondary[100],
-    tertiary: theme.colors.brand.tertiary[100],
-    positive: theme.colors.feedback.positive[100],
-    negative: theme.colors.feedback.negative[100],
-    warning: theme.colors.feedback.warning[100],
-    disabled: theme.colors.neutral.grayStrongDark[25],
+  white: theme.colors.neutral.white[900],
+  black: theme.colors.neutral.grayStrongDark[800],
+  primary: theme.colors.brand.primary[500],
+  secondary: theme.colors.brand.secondary[500],
+  tertiary: theme.colors.brand.tertiary[500],
+  positive: theme.colors.feedback.positive[500],
+  negative: theme.colors.feedback.negative[500],
+  warning: theme.colors.feedback.warning[500],
 } as const;
 
 const buttonColorExtraSoftMap = {
-    white: theme.colors.neutral.white[900],
-    black: theme.colors.neutral.black[50],
-    grayStrongDark: theme.colors.neutral.grayStrongDark[50],
-    graySoft: theme.colors.neutral.graySoft[50],
-    primary: theme.colors.brand.primary[50],
-    secondary: theme.colors.brand.secondary[50],
-    tertiary: theme.colors.brand.tertiary[50],
-    positive: theme.colors.feedback.positive[50],
-    negative: theme.colors.feedback.negative[50],
-    warning: theme.colors.feedback.warning[50],
+  white: theme.colors.neutral.graySoft[50],
+  black: null,
+  primary: theme.colors.brand.primary[50],
+  secondary: theme.colors.brand.secondary[50],
+  tertiary: theme.colors.brand.tertiary[50],
+  positive: theme.colors.feedback.positive[50],
+  negative: theme.colors.feedback.negative[50],
+  warning: theme.colors.feedback.warning[50],
+} as const;
+
+const buttonColorSoftMap = {
+  white: theme.colors.neutral.graySoft[100],
+  black: null,
+  primary: theme.colors.brand.primary[100],
+  secondary: theme.colors.brand.secondary[100],
+  tertiary: theme.colors.brand.tertiary[100],
+  positive: theme.colors.feedback.positive[100],
+  negative: theme.colors.feedback.negative[100],
+  warning: theme.colors.feedback.warning[100],
 } as const;
 
 const buttonColorDarkMap = {
-    white: theme.colors.neutral.white[900],
-    black: theme.colors.neutral.black[600],
-    grayStrongDark: theme.colors.neutral.grayStrongDark[600],
-    graySoft: theme.colors.neutral.graySoft[600],
-    primary: theme.colors.brand.primary[600],
-    secondary: theme.colors.brand.secondary[600],
-    tertiary: theme.colors.brand.tertiary[600],
-    positive: theme.colors.feedback.positive[600],
-    negative: theme.colors.feedback.negative[600],
-    warning: theme.colors.feedback.warning[600],
+  white: null,
+  black: theme.colors.neutral.grayStrongDark[800],
+  primary: theme.colors.brand.primary[600],
+  secondary: theme.colors.brand.secondary[600],
+  tertiary: theme.colors.brand.tertiary[600],
+  positive: theme.colors.feedback.positive[600],
+  negative: theme.colors.feedback.negative[600],
+  warning: theme.colors.feedback.warning[600],
 } as const;
 
 function stateKey(
   colorVariant?: keyof typeof buttonColorDefaultMap,
-  dark?: boolean,
-  disabled?: boolean
 ): keyof typeof buttonColorDefaultMap {
   if (colorVariant) return colorVariant;
-  if (disabled) return 'disabled';
-  // Fallback to a valid key, e.g., 'primary'
   return 'primary';
+}
+
+function resolveButtonColor(
+  colorVariant: keyof typeof buttonColorDefaultMap,
+  dark?: boolean,
+): string | null {
+  if (colorVariant === 'white') {
+    return theme.colors.neutral.grayStrongDark[800];
+  }
+
+  if (!dark) {
+    return buttonColorDefaultMap[colorVariant];
+  }
+
+  return buttonColorDarkMap[colorVariant];
 }
 
 export const buttonSx = (opts: {
@@ -90,9 +91,9 @@ export const buttonSx = (opts: {
   dark?: boolean;
   disabled?: boolean;
   size?: keyof typeof fontSizeMap;
-  buttonVariant?:  'default' | 'ghost' | 'light' | 'soft' | 'outline';
+  buttonVariant?: 'default' | 'ghost' | 'light' | 'soft' | 'outline';
 }): SxProps<Theme> => {
-  const colorKey = stateKey(opts.colorVariant, opts.dark, opts.disabled) ?? 'primary';
+  const colorKey = stateKey(opts.colorVariant);
 
   const borderRadius = borderRadiusMap[opts.borderRadius ?? 'normal'];
   const fontSize = fontSizeMap[opts.size ?? 'medium'];
@@ -105,22 +106,78 @@ export const buttonSx = (opts: {
     fontSize,
     fontWeight: '400',
     textTransform: 'none',
+    backgroundColor: !opts.dark ? buttonColorDefaultMap[colorKey] : buttonColorDarkMap[colorKey],
+    color:
+      opts.colorVariant !== 'white'
+        ? theme.colors.neutral.white[900]
+        : theme.colors.neutral.grayStrongDark[800],
     cursor: opts.disabled ? 'not-allowed' : 'pointer',
     svg: {
       fontSize: iconSize,
+    },
+    padding: '0.625rem 1.188rem',
+    '&.Mui-disabled': {
+      backgroundColor: theme.colors.neutral.grayStrongDark[25],
+      borderColor: theme.colors.neutral.grayStrongDark[50],
+      color: theme.colors.neutral.grayStrongDark[50],
     },
   };
 
   if (buttonVariant === 'default') {
     return {
       ...baseStyles,
-      // backgroundColor: ,
-      color: opts.disabled
-        ? buttonColorDefaultMap.disabled
-        : buttonColorDefaultMap[colorKey],
-      border: `1px solid ${buttonColorDefaultMap[colorKey]}`,
-      '&:hover': {
-        backgroundColor: buttonColorSoftMap[colorKey],
+    };
+  }
+
+  if (buttonVariant === 'ghost') {
+    return {
+      ...baseStyles,
+      background: 'none',
+      color: resolveButtonColor(colorKey, opts.dark),
+      '&.Mui-disabled': {
+        borderColor: 'none',
+      },
+    };
+  }
+
+  if (buttonVariant === 'light') {
+    return {
+      ...baseStyles,
+      backgroundColor: !opts.dark
+        ? buttonColorExtraSoftMap[colorKey]
+        : buttonColorDarkMap[colorKey],
+      color: resolveButtonColor(colorKey, opts.dark),
+      '&.Mui-disabled': {
+        backgroundColor: theme.colors.neutral.grayStrongDark[25],
+        borderColor: 'none',
+      },
+    };
+  }
+
+  if (buttonVariant === 'soft') {
+    return {
+      ...baseStyles,
+      backgroundColor: !opts.dark
+        ? buttonColorExtraSoftMap[colorKey]
+        : buttonColorDarkMap[colorKey],
+      borderWidth: '1px',
+      borderStyle: 'solid',
+      borderColor: buttonColorSoftMap[colorKey],
+      color: resolveButtonColor(colorKey, opts.dark),
+      '&.Mui-disabled': {
+        backgroundColor: theme.colors.neutral.grayStrongDark[25],
+        borderColor: theme.colors.neutral.grayStrongDark[50],
+      },
+    };
+  }
+
+  if (buttonVariant === 'outline') {
+    return {
+      ...baseStyles,
+      background: 'none',
+      color: resolveButtonColor(colorKey, opts.dark),
+      '&.Mui-disabled': {
+        borderColor: theme.colors.neutral.grayStrongDark[50],
       },
     };
   }

--- a/src/ui/components/atoms/button-filled/ButtonFilled.styles.ts
+++ b/src/ui/components/atoms/button-filled/ButtonFilled.styles.ts
@@ -32,7 +32,7 @@ const buttonColorDefaultMap = {
 
 const buttonColorExtraSoftMap = {
   white: theme.colors.neutral.graySoft[50],
-  black: null,
+  black: theme.colors.neutral.graySoft[50],
   primary: theme.colors.brand.primary[50],
   secondary: theme.colors.brand.secondary[50],
   tertiary: theme.colors.brand.tertiary[50],
@@ -43,7 +43,7 @@ const buttonColorExtraSoftMap = {
 
 const buttonColorSoftMap = {
   white: theme.colors.neutral.graySoft[100],
-  black: null,
+  black: theme.colors.neutral.graySoft[100],
   primary: theme.colors.brand.primary[100],
   secondary: theme.colors.brand.secondary[100],
   tertiary: theme.colors.brand.tertiary[100],
@@ -53,7 +53,7 @@ const buttonColorSoftMap = {
 } as const;
 
 const buttonColorDarkMap = {
-  white: null,
+  white: theme.colors.neutral.white[900],
   black: theme.colors.neutral.grayStrongDark[800],
   primary: theme.colors.brand.primary[600],
   secondary: theme.colors.brand.secondary[600],
@@ -83,6 +83,21 @@ function resolveButtonColor(
   }
 
   return buttonColorDarkMap[colorVariant];
+}
+
+function resolveTextButtonColor(
+  colorVariant: keyof typeof buttonColorDefaultMap,
+  dark?: boolean,
+): string | null {
+  if (colorVariant === 'white') {
+    return theme.colors.neutral.grayStrongDark[800];
+  }
+
+  if (!dark) {
+    return buttonColorDefaultMap[colorVariant];
+  }
+
+  return theme.colors.neutral.white[900];
 }
 
 export const buttonSx = (opts: {
@@ -146,7 +161,9 @@ export const buttonSx = (opts: {
       backgroundColor: !opts.dark
         ? buttonColorExtraSoftMap[colorKey]
         : buttonColorDarkMap[colorKey],
-      color: resolveButtonColor(colorKey, opts.dark),
+      color: !opts.dark
+        ? resolveButtonColor(colorKey, opts.dark)
+        : resolveTextButtonColor(colorKey, opts.dark),
       '&.Mui-disabled': {
         backgroundColor: theme.colors.neutral.grayStrongDark[25],
         borderColor: 'none',
@@ -162,8 +179,12 @@ export const buttonSx = (opts: {
         : buttonColorDarkMap[colorKey],
       borderWidth: '1px',
       borderStyle: 'solid',
-      borderColor: buttonColorSoftMap[colorKey],
-      color: resolveButtonColor(colorKey, opts.dark),
+      borderColor: !opts.dark
+        ? buttonColorSoftMap[colorKey]
+        : resolveButtonColor(colorKey, opts.dark),
+      color: !opts.dark
+        ? resolveButtonColor(colorKey, opts.dark)
+        : resolveTextButtonColor(colorKey, opts.dark),
       '&.Mui-disabled': {
         backgroundColor: theme.colors.neutral.grayStrongDark[25],
         borderColor: theme.colors.neutral.grayStrongDark[50],
@@ -174,11 +195,13 @@ export const buttonSx = (opts: {
   if (buttonVariant === 'outline') {
     return {
       ...baseStyles,
-      background: 'none',
+      backgroundColor: !opts.dark ? 'transparent' : buttonColorDarkMap[colorKey],
       borderWidth: '1px',
       borderStyle: 'solid',
-      borderColor: buttonColorDefaultMap[colorKey],
-      color: resolveButtonColor(colorKey, opts.dark),
+      borderColor: resolveButtonColor(colorKey, opts.dark),
+      color: !opts.dark
+        ? resolveButtonColor(colorKey, opts.dark)
+        : resolveTextButtonColor(colorKey, opts.dark),
       '&.Mui-disabled': {
         borderColor: theme.colors.neutral.grayStrongDark[50],
       },

--- a/src/ui/components/atoms/button-filled/ButtonFilled.styles.ts
+++ b/src/ui/components/atoms/button-filled/ButtonFilled.styles.ts
@@ -1,7 +1,25 @@
 import type { SxProps, Theme } from '@mui/material';
 import { theme } from '../../../../globals/theme';
 
-const buttonColorMap = {
+const borderRadiusMap = {
+    normal: '0',
+    semi: '0.5rem',
+    circle: '3.125rem',
+} as const;
+
+const fontSizeMap = {
+    small: '1rem',
+    medium: '1.125rem',
+    large: '1.25rem',
+} as const;
+
+const iconSizeMap = {
+    small: '1.125rem',
+    medium: '1.25rem',
+    large: '1.5rem',
+} as const;
+
+const buttonColorDefaultMap = {
     white: theme.colors.neutral.white[900],
     black: theme.colors.neutral.black[500],
     grayStrongDark: theme.colors.neutral.grayStrongDark[500],
@@ -12,66 +30,100 @@ const buttonColorMap = {
     positive: theme.colors.feedback.positive[500],
     negative: theme.colors.feedback.negative[500],
     warning: theme.colors.feedback.warning[500],
-    disabled: theme.colors.neutral.grayStrongDark[25],
+    disabled: theme.colors.neutral.grayStrongDark[50],
 } as const;
 
-const buttonBackgroundColorMap = {
+const buttonColorSoftMap = {
     white: theme.colors.neutral.white[900],
-    black: theme.colors.neutral.black[500],
-    grayStrongDark: theme.colors.neutral.grayStrongDark[500],
-    graySoft: theme.colors.neutral.graySoft[500],
-    primary: theme.colors.brand.primary[500],
-    secondary: theme.colors.brand.secondary[500],
-    tertiary: theme.colors.brand.tertiary[500],
-    positive: theme.colors.feedback.positive[500],
-    negative: theme.colors.feedback.negative[500],
-    warning: theme.colors.feedback.warning[500],
+    black: theme.colors.neutral.black[100],
+    grayStrongDark: theme.colors.neutral.grayStrongDark[100],
+    graySoft: theme.colors.neutral.graySoft[100],
+    primary: theme.colors.brand.primary[100],
+    secondary: theme.colors.brand.secondary[100],
+    tertiary: theme.colors.brand.tertiary[100],
+    positive: theme.colors.feedback.positive[100],
+    negative: theme.colors.feedback.negative[100],
+    warning: theme.colors.feedback.warning[100],
     disabled: theme.colors.neutral.grayStrongDark[25],
 } as const;
 
-const hoverButtonColorMap = {
-
+const buttonColorExtraSoftMap = {
+    white: theme.colors.neutral.white[900],
+    black: theme.colors.neutral.black[50],
+    grayStrongDark: theme.colors.neutral.grayStrongDark[50],
+    graySoft: theme.colors.neutral.graySoft[50],
+    primary: theme.colors.brand.primary[50],
+    secondary: theme.colors.brand.secondary[50],
+    tertiary: theme.colors.brand.tertiary[50],
+    positive: theme.colors.feedback.positive[50],
+    negative: theme.colors.feedback.negative[50],
+    warning: theme.colors.feedback.warning[50],
 } as const;
 
-const textButtonColorMap = {
-
+const buttonColorDarkMap = {
+    white: theme.colors.neutral.white[900],
+    black: theme.colors.neutral.black[600],
+    grayStrongDark: theme.colors.neutral.grayStrongDark[600],
+    graySoft: theme.colors.neutral.graySoft[600],
+    primary: theme.colors.brand.primary[600],
+    secondary: theme.colors.brand.secondary[600],
+    tertiary: theme.colors.brand.tertiary[600],
+    positive: theme.colors.feedback.positive[600],
+    negative: theme.colors.feedback.negative[600],
+    warning: theme.colors.feedback.warning[600],
 } as const;
 
-/* 
-neutral
-    white
-    black
-    grayStrongDark
-    graySoft
-
-brand
-    primary
-    secondary
-    tertiary
-
-feedback
-    positive
-    negative
-    warning
-
-*/
-
-function stateKey(color?: boolean, error?: boolean) {
-    if (color) return 'color';
-    if (error) return 'error';
-    return 'default';
+function stateKey(
+  colorVariant?: keyof typeof buttonColorDefaultMap,
+  dark?: boolean,
+  disabled?: boolean
+): keyof typeof buttonColorDefaultMap {
+  if (colorVariant) return colorVariant;
+  if (disabled) return 'disabled';
+  // Fallback to a valid key, e.g., 'primary'
+  return 'primary';
 }
 
-export const iconSx = (opts: {
-    disabled?: boolean;
-    error?: boolean;
-    size?: string;
+export const buttonSx = (opts: {
+  borderRadius?: keyof typeof borderRadiusMap;
+  colorVariant?: keyof typeof buttonColorDefaultMap;
+  dark?: boolean;
+  disabled?: boolean;
+  size?: keyof typeof fontSizeMap;
+  buttonVariant?:  'default' | 'ghost' | 'light' | 'soft' | 'outline';
 }): SxProps<Theme> => {
-    const colorKey = stateKey(opts.disabled, opts.error);
+  const colorKey = stateKey(opts.colorVariant, opts.dark, opts.disabled) ?? 'primary';
 
+  const borderRadius = borderRadiusMap[opts.borderRadius ?? 'normal'];
+  const fontSize = fontSizeMap[opts.size ?? 'medium'];
+  const iconSize = iconSizeMap[opts.size ?? 'medium'];
+
+  const buttonVariant = opts.buttonVariant ?? 'solid';
+
+  const baseStyles: SxProps<Theme> = {
+    borderRadius,
+    fontSize,
+    fontWeight: '400',
+    textTransform: 'none',
+    cursor: opts.disabled ? 'not-allowed' : 'pointer',
+    svg: {
+      fontSize: iconSize,
+    },
+  };
+
+  if (buttonVariant === 'default') {
     return {
-        // color: iconColorMap[colorKey],
-        maxWidth: opts.size ?? '1.125rem',
-        maxHeight: opts.size ?? '1.125rem',
+      ...baseStyles,
+      // backgroundColor: ,
+      color: opts.disabled
+        ? buttonColorDefaultMap.disabled
+        : buttonColorDefaultMap[colorKey],
+      border: `1px solid ${buttonColorDefaultMap[colorKey]}`,
+      '&:hover': {
+        backgroundColor: buttonColorSoftMap[colorKey],
+      },
     };
+  }
+
+  return baseStyles;
 };

--- a/src/ui/components/atoms/button-filled/ButtonFilled.styles.ts
+++ b/src/ui/components/atoms/button-filled/ButtonFilled.styles.ts
@@ -1,0 +1,77 @@
+import type { SxProps, Theme } from '@mui/material';
+import { theme } from '../../../../globals/theme';
+
+const buttonColorMap = {
+    white: theme.colors.neutral.white[900],
+    black: theme.colors.neutral.black[500],
+    grayStrongDark: theme.colors.neutral.grayStrongDark[500],
+    graySoft: theme.colors.neutral.graySoft[500],
+    primary: theme.colors.brand.primary[500],
+    secondary: theme.colors.brand.secondary[500],
+    tertiary: theme.colors.brand.tertiary[500],
+    positive: theme.colors.feedback.positive[500],
+    negative: theme.colors.feedback.negative[500],
+    warning: theme.colors.feedback.warning[500],
+    disabled: theme.colors.neutral.grayStrongDark[25],
+} as const;
+
+const buttonBackgroundColorMap = {
+    white: theme.colors.neutral.white[900],
+    black: theme.colors.neutral.black[500],
+    grayStrongDark: theme.colors.neutral.grayStrongDark[500],
+    graySoft: theme.colors.neutral.graySoft[500],
+    primary: theme.colors.brand.primary[500],
+    secondary: theme.colors.brand.secondary[500],
+    tertiary: theme.colors.brand.tertiary[500],
+    positive: theme.colors.feedback.positive[500],
+    negative: theme.colors.feedback.negative[500],
+    warning: theme.colors.feedback.warning[500],
+    disabled: theme.colors.neutral.grayStrongDark[25],
+} as const;
+
+const hoverButtonColorMap = {
+
+} as const;
+
+const textButtonColorMap = {
+
+} as const;
+
+/* 
+neutral
+    white
+    black
+    grayStrongDark
+    graySoft
+
+brand
+    primary
+    secondary
+    tertiary
+
+feedback
+    positive
+    negative
+    warning
+
+*/
+
+function stateKey(color?: boolean, error?: boolean) {
+    if (color) return 'color';
+    if (error) return 'error';
+    return 'default';
+}
+
+export const iconSx = (opts: {
+    disabled?: boolean;
+    error?: boolean;
+    size?: string;
+}): SxProps<Theme> => {
+    const colorKey = stateKey(opts.disabled, opts.error);
+
+    return {
+        // color: iconColorMap[colorKey],
+        maxWidth: opts.size ?? '1.125rem',
+        maxHeight: opts.size ?? '1.125rem',
+    };
+};

--- a/src/ui/components/atoms/button-filled/ButtonFilled.styles.ts
+++ b/src/ui/components/atoms/button-filled/ButtonFilled.styles.ts
@@ -175,6 +175,9 @@ export const buttonSx = (opts: {
     return {
       ...baseStyles,
       background: 'none',
+      borderWidth: '1px',
+      borderStyle: 'solid',
+      borderColor: buttonColorDefaultMap[colorKey],
       color: resolveButtonColor(colorKey, opts.dark),
       '&.Mui-disabled': {
         borderColor: theme.colors.neutral.grayStrongDark[50],

--- a/src/ui/components/atoms/button-filled/ButtonFilled.test.tsx
+++ b/src/ui/components/atoms/button-filled/ButtonFilled.test.tsx
@@ -1,0 +1,63 @@
+// import { render, screen, fireEvent } from '@testing-library/react';
+// import { InputCountry } from './InputCountry';
+
+// interface Option {
+//   country: string;
+//   code: string;
+// }
+// const options: Option[] = [
+//   { country: 'Argentina', code: 'ar' },
+//   { country: 'Bolivia', code: 'bo' },
+//   { country: 'Chile', code: 'cl' },
+//   { country: 'Perú', code: 'pe' },
+// ];
+
+// describe('InputCountry Component', () => {
+//   it('renders with label', () => {
+//     render(<InputCountry label="Select Country" helperText="hint" options={options} />);
+//     expect(screen.getByText('Select Country')).toBeInTheDocument();
+//   });
+
+//   it('renders with helperText and error', () => {
+//     render(<InputCountry label="Select Country" options={options} error helperText="Error text" />);
+//     expect(screen.getByText('Error text')).toBeInTheDocument();
+//   });
+
+//   it('renders disabled state', () => {
+//     render(
+//       <InputCountry label="Select Country" options={options} helperText="Hint Text" disabled />,
+//     );
+//     const select = screen.getByRole('combobox');
+//     expect(select).toHaveAttribute('aria-disabled', 'true');
+//   });
+
+//   it('changes value on select', () => {
+//     render(<InputCountry label="Select Country" options={options} helperText="Hint Text" />);
+//     const select = screen.getByRole('combobox');
+//     fireEvent.mouseDown(select);
+//     const option = screen.getByText('Bolivia');
+//     fireEvent.click(option);
+//     expect(screen.getByText('Argentina')).toBeInTheDocument();
+//   });
+
+//   it('matches snapshot in empty state', () => {
+//     const { container } = render(
+//       <InputCountry label="Country" options={options} helperText="Hint Text" />,
+//     );
+//     expect(container).toMatchSnapshot();
+//   });
+
+//   it('matches snapshot with error', () => {
+//     const { container } = render(
+//       <InputCountry label="Country" options={options} error helperText="Hint Text" />,
+//     );
+//     expect(container).toMatchSnapshot();
+//   });
+
+//   it('matches snapshot disabled', () => {
+//     const { container } = render(
+//       <InputCountry label="Country" options={options} helperText="Hint Text" disabled />,
+//     );
+//     expect(container).toMatchSnapshot();
+//   });
+// });

--- a/src/ui/components/atoms/button-filled/ButtonFilled.test.tsx
+++ b/src/ui/components/atoms/button-filled/ButtonFilled.test.tsx
@@ -1,63 +1,57 @@
-// import { render, screen, fireEvent } from '@testing-library/react';
-// import { InputCountry } from './InputCountry';
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { ButtonFilled } from './ButtonFilled';
 
-// interface Option {
-//   country: string;
-//   code: string;
-// }
-// const options: Option[] = [
-//   { country: 'Argentina', code: 'ar' },
-//   { country: 'Bolivia', code: 'bo' },
-//   { country: 'Chile', code: 'cl' },
-//   { country: 'Perú', code: 'pe' },
-// ];
+// Tipado explícito y sin prop spreading
+vi.mock('@mui/material', () => ({
+  Button: ({
+    children,
+    'data-testid': dataTestId,
+    disabled,
+    startIcon,
+    endIcon,
+  }: {
+    children: ReactNode;
+    'data-testid'?: string;
+    disabled?: boolean;
+    startIcon?: ReactNode;
+    endIcon?: ReactNode;
+  }) => (
+    <button data-testid={dataTestId} disabled={disabled}>
+      {startIcon}
+      {children}
+      {endIcon}
+    </button>
+  ),
+}));
 
-// describe('InputCountry Component', () => {
-//   it('renders with label', () => {
-//     render(<InputCountry label="Select Country" helperText="hint" options={options} />);
-//     expect(screen.getByText('Select Country')).toBeInTheDocument();
-//   });
+describe('ButtonFilled', () => {
+  it('renders with required text', () => {
+    const { getByText } = render(<ButtonFilled text="Button text" />);
+    expect(getByText('Button text')).toBeTruthy();
+  });
 
-//   it('renders with helperText and error', () => {
-//     render(<InputCountry label="Select Country" options={options} error helperText="Error text" />);
-//     expect(screen.getByText('Error text')).toBeInTheDocument();
-//   });
+  it('applies disabled prop', () => {
+    const { getByTestId } = render(<ButtonFilled text="Disabled" disabled />);
+    expect(getByTestId('mui-button')).toBeDisabled();
+  });
 
-//   it('renders disabled state', () => {
-//     render(
-//       <InputCountry label="Select Country" options={options} helperText="Hint Text" disabled />,
-//     );
-//     const select = screen.getByRole('combobox');
-//     expect(select).toHaveAttribute('aria-disabled', 'true');
-//   });
+  it('applies colorVariant, dark, size, buttonVariant', () => {
+    const { getByTestId } = render(
+      <ButtonFilled
+        text="Props"
+        colorVariant="primary"
+        dark
+        size="large"
+        buttonVariant="outline"
+      />,
+    );
+    expect(getByTestId('mui-button')).toBeTruthy();
+  });
 
-//   it('changes value on select', () => {
-//     render(<InputCountry label="Select Country" options={options} helperText="Hint Text" />);
-//     const select = screen.getByRole('combobox');
-//     fireEvent.mouseDown(select);
-//     const option = screen.getByText('Bolivia');
-//     fireEvent.click(option);
-//     expect(screen.getByText('Argentina')).toBeInTheDocument();
-//   });
-
-//   it('matches snapshot in empty state', () => {
-//     const { container } = render(
-//       <InputCountry label="Country" options={options} helperText="Hint Text" />,
-//     );
-//     expect(container).toMatchSnapshot();
-//   });
-
-//   it('matches snapshot with error', () => {
-//     const { container } = render(
-//       <InputCountry label="Country" options={options} error helperText="Hint Text" />,
-//     );
-//     expect(container).toMatchSnapshot();
-//   });
-
-//   it('matches snapshot disabled', () => {
-//     const { container } = render(
-//       <InputCountry label="Country" options={options} helperText="Hint Text" disabled />,
-//     );
-//     expect(container).toMatchSnapshot();
-//   });
-// });
+  it('forwards sx styles from buttonSx', () => {
+    const { getByTestId } = render(<ButtonFilled text="Styled" />);
+    expect(getByTestId('mui-button')).toBeTruthy();
+  });
+});

--- a/src/ui/components/atoms/button-filled/ButtonFilled.tsx
+++ b/src/ui/components/atoms/button-filled/ButtonFilled.tsx
@@ -1,19 +1,39 @@
-import React from 'react';
+import { Button } from '@mui/material';
 import type { IProps } from './types/IProps';
-import { Box, Button } from '@mui/material';
-import { theme } from 'globals/theme';
 
-import CancelOutlinedIcon from '@mui/icons-material/CancelOutlined';
 import { buttonSx } from './ButtonFilled.styles';
 
 export function ButtonFilled(props: IProps) {
-    const { text, startIcon, endIcon, borderRadius, colorVariant, dark, disabled, size, buttonVariant } = props;
+  const {
+    text,
+    startIcon,
+    endIcon,
+    borderRadius,
+    colorVariant,
+    dark,
+    disabled,
+    size,
+    buttonVariant,
+  } = props;
 
-    const buttonStyles = buttonSx({ borderRadius, colorVariant, dark, disabled, size, buttonVariant });
+  const buttonStyles = buttonSx({
+    borderRadius,
+    colorVariant,
+    dark,
+    disabled,
+    size,
+    buttonVariant,
+  });
 
-    return (
-        <Box>
-            <Button sx={buttonStyles} startIcon={<CancelOutlinedIcon />} endIcon={<CancelOutlinedIcon />}>{text}</Button>
-        </Box>
-    );
+  return (
+    <Button
+      sx={buttonStyles}
+      startIcon={startIcon}
+      endIcon={endIcon}
+      disabled={disabled}
+      data-testid="mui-button"
+    >
+      {text}
+    </Button>
+  );
 }

--- a/src/ui/components/atoms/button-filled/ButtonFilled.tsx
+++ b/src/ui/components/atoms/button-filled/ButtonFilled.tsx
@@ -4,14 +4,16 @@ import { Box, Button } from '@mui/material';
 import { theme } from 'globals/theme';
 
 import CancelOutlinedIcon from '@mui/icons-material/CancelOutlined';
+import { buttonSx } from './ButtonFilled.styles';
 
 export function ButtonFilled(props: IProps) {
-    const { text, textColor, buttonColor, startIcon, endIcon, disabled, borderRadius, size, dark } = props;
+    const { text, startIcon, endIcon, borderRadius, colorVariant, dark, disabled, size, buttonVariant } = props;
 
-    
+    const buttonStyles = buttonSx({ borderRadius, colorVariant, dark, disabled, size, buttonVariant });
+
     return (
         <Box>
-            <Button sx={{backgroundColor: theme.colors.brand.primary[100]}} startIcon={<CancelOutlinedIcon />} endIcon={<CancelOutlinedIcon />}>{text}</Button>
+            <Button sx={buttonStyles} startIcon={<CancelOutlinedIcon />} endIcon={<CancelOutlinedIcon />}>{text}</Button>
         </Box>
     );
 }

--- a/src/ui/components/atoms/button-filled/ButtonFilled.tsx
+++ b/src/ui/components/atoms/button-filled/ButtonFilled.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import type { IProps } from './types/IProps';
+import { Box, Button } from '@mui/material';
+import { theme } from 'globals/theme';
+
+import CancelOutlinedIcon from '@mui/icons-material/CancelOutlined';
+
+export function ButtonFilled(props: IProps) {
+    const { text, textColor, buttonColor, startIcon, endIcon, disabled, borderRadius, size, dark } = props;
+
+    
+    return (
+        <Box>
+            <Button sx={{backgroundColor: theme.colors.brand.primary[100]}} startIcon={<CancelOutlinedIcon />} endIcon={<CancelOutlinedIcon />}>{text}</Button>
+        </Box>
+    );
+}

--- a/src/ui/components/atoms/button-filled/types/IProps.ts
+++ b/src/ui/components/atoms/button-filled/types/IProps.ts
@@ -1,12 +1,39 @@
-import React from "react";
+import type { ReactNode } from 'react';
 
 export interface IProps {
   text: string;
-  startIcon?: React.ReactNode;
-  endIcon?: React.ReactNode;
+  startIcon?: ReactNode;
+  endIcon?: ReactNode;
 
   borderRadius?: 'normal' | 'semi' | 'circle';
-  colorVariant?: "disabled" | "white" | "black" | "grayStrongDark" | "graySoft" | "primary" | "secondary" | "tertiary" | "positive" | "negative" | "warning";
+  colorVariant?:
+    | 'white'
+    | 'black'
+    | 'primary'
+    | 'secondary'
+    | 'tertiary'
+    | 'positive'
+    | 'negative'
+    | 'warning';
+  dark?: boolean;
+  disabled?: boolean;
+  size?: 'small' | 'medium' | 'large';
+  buttonVariant?: 'default' | 'ghost' | 'light' | 'soft' | 'outline';
+}
+
+export interface IPropsStorybook {
+  text: string;
+
+  borderRadius?: 'normal' | 'semi' | 'circle';
+  colorVariant?:
+    | 'white'
+    | 'black'
+    | 'primary'
+    | 'secondary'
+    | 'tertiary'
+    | 'positive'
+    | 'negative'
+    | 'warning';
   dark?: boolean;
   disabled?: boolean;
   size?: 'small' | 'medium' | 'large';

--- a/src/ui/components/atoms/button-filled/types/IProps.ts
+++ b/src/ui/components/atoms/button-filled/types/IProps.ts
@@ -2,14 +2,13 @@ import React from "react";
 
 export interface IProps {
   text: string;
-  textColor?: string;
-
-  buttonColor?: string;
-  dark?: boolean;
-
   startIcon?: React.ReactNode;
   endIcon?: React.ReactNode;
-  disabled?: boolean;
+
   borderRadius?: 'normal' | 'semi' | 'circle';
+  colorVariant?: "disabled" | "white" | "black" | "grayStrongDark" | "graySoft" | "primary" | "secondary" | "tertiary" | "positive" | "negative" | "warning";
+  dark?: boolean;
+  disabled?: boolean;
   size?: 'small' | 'medium' | 'large';
+  buttonVariant?: 'default' | 'ghost' | 'light' | 'soft' | 'outline';
 }

--- a/src/ui/components/atoms/button-filled/types/IProps.ts
+++ b/src/ui/components/atoms/button-filled/types/IProps.ts
@@ -1,0 +1,15 @@
+import React from "react";
+
+export interface IProps {
+  text: string;
+  textColor?: string;
+
+  buttonColor?: string;
+  dark?: boolean;
+
+  startIcon?: React.ReactNode;
+  endIcon?: React.ReactNode;
+  disabled?: boolean;
+  borderRadius?: 'normal' | 'semi' | 'circle';
+  size?: 'small' | 'medium' | 'large';
+}


### PR DESCRIPTION
Filled button add as is show in figma  
Button also has a **dark mode** for all colors and variants.
## Colors used (default button uses primary colors):
Primary
![image](https://github.com/user-attachments/assets/c5cb34aa-bc3e-4038-b740-eb59968e1128)

Secondary
![image](https://github.com/user-attachments/assets/86067ff3-5d56-401b-8c47-ed6ffd440b4d)

Tertiary
![image](https://github.com/user-attachments/assets/30538be6-41a8-4383-81b8-abdc9a367ef9)

White
![image](https://github.com/user-attachments/assets/3c03734d-43c3-4818-8689-3f324895153a)

Black
![image](https://github.com/user-attachments/assets/0ef4b0fb-05bb-402c-a255-ad7e10040228)

Positive
![image](https://github.com/user-attachments/assets/95c46888-4196-4ee5-b35a-0a033ac6a379)

Negative
![image](https://github.com/user-attachments/assets/b8cbd07f-49c0-44cf-9388-81a77e9082d0)

Warning
![image](https://github.com/user-attachments/assets/7c3a197c-0f3b-47f5-b4dc-f1f3e255430c)

## Border radius
Normal
![image](https://github.com/user-attachments/assets/6ab9494d-bcf8-4c89-948a-6ea250f16bc7)

Semi
![image](https://github.com/user-attachments/assets/b00d292d-61f7-4815-916e-c368d77c0868)

Circle
![image](https://github.com/user-attachments/assets/7e9f032e-5320-4148-9a82-2628c59eb302)

## Variants of the button:
Default
![image](https://github.com/user-attachments/assets/44096c8a-00a1-43a5-ad4b-cb1875c338f5)

Ghost
![image](https://github.com/user-attachments/assets/29d95b96-497d-4ecc-a06a-573d8d95bac1)

Soft
![image](https://github.com/user-attachments/assets/82d56b11-2f61-4c58-a590-280058cb8d36)

Light
![image](https://github.com/user-attachments/assets/9011481e-9627-43bd-ac1f-9f120279d458)

Outline
![image](https://github.com/user-attachments/assets/6deadb9d-a20c-434b-a32f-4bd3188f53ee)

> [!TIP]
> Check the color palette, primary and secondary colors have the same colors.